### PR TITLE
Add Russian Monopoly prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Russian Monopoly Prototype
+
+This repository contains a prototype for an online board game inspired by Monopoly with Russian cultural themes. The demo showcases browser-based gameplay with multi-language support, auctions, random events and the ability to build residences.
+
+## Project structure
+
+- `index.html` – demo page.
+- `css/styles.css` – basic styles.
+- `js/data.js` – placeholder data for board tiles, chance cards, random events and players.
+- `js/game.js` – main game logic (movement, buying property, auctions, paying rent, building residences).
+
+## Features
+
+- Multi-language interface (English/Russian).
+- Buying properties and paying rent with the ability to build residences that double rent when owning all properties of the same color.
+- Auctions triggered when a player declines to purchase a property.
+- Random economic and weather events influencing rent and movement.
+- Placeholder chance cards with Russian cultural references.
+
+## Running
+
+Open `index.html` in a modern browser. Use the **Roll Dice** button to move player tokens. When eligible, use **Build Residence** to invest in owned property. The log panel displays game actions.
+
+This is only a starting point for a more complex multiplayer game with Russian-specific mechanics, events and customizations.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,32 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+#game {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+#board {
+  border: 2px solid #333;
+  margin-bottom: 10px;
+}
+#controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+#controls button {
+  margin: 5px;
+}
+#log {
+  border: 1px solid #ccc;
+  padding: 5px;
+  width: 300px;
+  height: 150px;
+  overflow-y: auto;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Русская Монополия - Прототип</title>
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <div id="language-select">
+    <label for="lang">Language:</label>
+    <select id="lang">
+      <option value="en">English</option>
+      <option value="ru">Русский</option>
+    </select>
+  </div>
+  <div id="game">
+    <canvas id="board" width="1000" height="600"></canvas>
+    <div id="controls">
+      <button id="roll">Roll Dice</button>
+      <button id="build" style="display:none">Build Residence</button>
+      <div id="log"></div>
+    </div>
+  </div>
+  <script src="js/data.js"></script>
+  <script src="js/game.js"></script>
+</body>
+</html>

--- a/js/data.js
+++ b/js/data.js
@@ -1,0 +1,33 @@
+// Placeholder data for board tiles, chance cards, players and events
+const boardTiles = [
+  { id: 0, name: { en: 'Start', ru: 'Старт' }, price: 0, rent: 0 },
+  { id: 1, name: { en: 'Moscow', ru: 'Москва' }, color: 'red', price: 100, rent: 10, residenceCost: 100 },
+  { id: 2, name: { en: 'Chance', ru: 'Шанс' }, type: 'chance' },
+  { id: 3, name: { en: 'Saint Petersburg', ru: 'Санкт-Петербург' }, color: 'red', price: 120, rent: 12, residenceCost: 100 },
+  { id: 4, name: { en: 'Tax', ru: 'Налог' }, type: 'tax', amount: 50 },
+  { id: 5, name: { en: 'Sochi', ru: 'Сочи' }, color: 'blue', price: 80, rent: 8, residenceCost: 80 },
+  { id: 6, name: { en: 'Chance', ru: 'Шанс' }, type: 'chance' },
+  { id: 7, name: { en: 'Novosibirsk', ru: 'Новосибирск' }, color: 'blue', price: 90, rent: 9, residenceCost: 80 },
+  { id: 8, name: { en: 'Kazan', ru: 'Казань' }, color: 'green', price: 110, rent: 11, residenceCost: 100 },
+  { id: 9, name: { en: 'Yekaterinburg', ru: 'Екатеринбург' }, color: 'green', price: 120, rent: 12, residenceCost: 100 },
+];
+
+const chanceCards = [
+  { en: 'You won tickets to the Bolshoi Theater! Collect 50.', ru: 'Вы выиграли билеты в Большой театр! Получите 50.', effect: p => p.money += 50 },
+  { en: 'Trans-Siberian journey. Pay 30.', ru: 'Транссибирское путешествие. Заплатите 30.', effect: p => p.money -= 30 },
+  { en: 'Kremlin tour. Advance to Moscow.', ru: 'Экскурсия в Кремль. Перейдите в Москву.', effect: p => p.position = 1 },
+  { en: 'Pay tribute to the Hermitage. Pay 40.', ru: 'Отдайте дань Эрмитажу. Заплатите 40.', effect: p => p.money -= 40 },
+];
+
+const randomEvents = [
+  { en: 'Economic boom! Rent +50%.', ru: 'Экономический бум! Аренда +50%.', effect: m => m.rent = 1.5 },
+  { en: 'Economic crisis! Rent -50%.', ru: 'Экономический кризис! Аренда -50%.', effect: m => m.rent = 0.5 },
+  { en: 'Snow storm in Siberia. Move only 1 tile.', ru: 'Снежная буря в Сибири. Ход только на 1 клетку.', effect: m => m.movement = 1 },
+  { en: 'Summer festival! Rent doubled this turn.', ru: 'Летний фестиваль! Аренда удвоена.', effect: m => m.rent = 2 },
+  null, // sometimes no event occurs
+];
+
+const playerTemplates = [
+  { id: 0, name: 'Player 1', token: '🎩', position: 0, money: 1500, properties: [] },
+  { id: 1, name: 'Player 2', token: '🐻', position: 0, money: 1500, properties: [] },
+];

--- a/js/game.js
+++ b/js/game.js
@@ -1,0 +1,200 @@
+// Basic translations for multi-language support
+const translations = {
+  en: {
+    buy: 'Buy',
+    payRent: 'Pay rent',
+    noMoney: 'Not enough money',
+    build: 'Build',
+  },
+  ru: {
+    buy: 'Купить',
+    payRent: 'Оплатить аренду',
+    noMoney: 'Недостаточно денег',
+    build: 'Построить',
+  },
+};
+
+// current UI language
+let lang = 'en';
+const langSelect = document.getElementById('lang');
+const buildBtn = document.getElementById('build');
+langSelect.addEventListener('change', e => {
+  lang = e.target.value;
+  if (buildBtn.style.display !== 'none') {
+    buildBtn.textContent = translations[lang].build;
+  }
+  renderLog(`Language changed to ${lang}`);
+});
+
+// canvas context for simple board rendering
+const canvas = document.getElementById('board');
+const ctx = canvas.getContext('2d');
+canvas.width = boardTiles.length * 100;
+
+// Player class stores basic state of each participant
+class Player {
+  constructor(template) {
+    Object.assign(this, JSON.parse(JSON.stringify(template)));
+  }
+}
+
+const players = playerTemplates.map(t => new Player(t));
+let currentPlayerIndex = 0;
+let currentTile = null;
+let modifiers = { rent: 1, movement: null };
+
+buildBtn.addEventListener('click', () => {
+  const player = players[currentPlayerIndex];
+  if (currentTile && canBuildResidence(player, currentTile) && player.money >= currentTile.residenceCost) {
+    player.money -= currentTile.residenceCost;
+    currentTile.residence = true;
+    renderLog(`${player.name} builds residence on ${currentTile.name[lang]}`);
+    buildBtn.style.display = 'none';
+  }
+});
+
+// draws the board and players tokens
+function renderBoard() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#f0f0f0';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  boardTiles.forEach((tile, i) => {
+    ctx.strokeRect(i * 100, 500, 100, 100);
+    ctx.fillText(tile.name[lang], i * 100 + 10, 520);
+    if (tile.owner !== undefined) {
+      const owner = players.find(p => p.id === tile.owner);
+      if (owner) ctx.fillText(owner.token, i * 100 + 80, 520);
+    }
+    if (tile.residence) {
+      ctx.fillText('🏠', i * 100 + 40, 520);
+    }
+  });
+  players.forEach(p => {
+    ctx.fillText(p.token, p.position * 100 + 50, 550);
+  });
+}
+
+// outputs a message to the log window
+function renderLog(msg) {
+  const log = document.getElementById('log');
+  log.innerHTML += msg + '<br />';
+  log.scrollTop = log.scrollHeight;
+}
+
+// simple 6-sided dice
+function rollDice() {
+  return Math.floor(Math.random() * 6) + 1;
+}
+
+function applyRandomEvent() {
+  modifiers = { rent: 1, movement: null };
+  const event = randomEvents[Math.floor(Math.random() * randomEvents.length)];
+  if (event) {
+    event.effect(modifiers);
+    renderLog(event[lang]);
+  }
+}
+
+// proceed to next player's turn
+function nextTurn() {
+  currentPlayerIndex = (currentPlayerIndex + 1) % players.length;
+}
+
+function startAuction(tile) {
+  renderLog(`Auction for ${tile.name[lang]}`);
+  let highest = 0;
+  let winner = null;
+  players.forEach(p => {
+    const bidStr = prompt(`${p.name} bid for ${tile.name[lang]} (0 pass)`);
+    const bid = parseInt(bidStr, 10);
+    if (!isNaN(bid) && bid > highest && bid <= p.money) {
+      highest = bid;
+      winner = p;
+    }
+  });
+  if (winner) {
+    winner.money -= highest;
+    tile.owner = winner.id;
+    winner.properties.push(tile.id);
+    renderLog(`${winner.name} wins auction for ${tile.name[lang]} with ${highest}`);
+  } else {
+    renderLog(`No bids for ${tile.name[lang]}`);
+  }
+}
+
+function canBuildResidence(player, tile) {
+  if (!tile.color || tile.residence) return false;
+  return boardTiles.filter(t => t.color === tile.color).every(t => t.owner === player.id);
+}
+
+// react to tile a player landed on
+function handleTile(player, tile) {
+  currentTile = tile;
+  buildBtn.style.display = 'none';
+
+  if (tile.type === 'chance') {
+    const card = chanceCards[Math.floor(Math.random() * chanceCards.length)];
+    card.effect(player);
+    renderLog(card[lang]);
+    return;
+  }
+  if (tile.type === 'tax') {
+    player.money -= tile.amount;
+    renderLog(`${player.name} pays tax ${tile.amount}`);
+    return;
+  }
+  if (!tile.owner && tile.price) {
+    if (player.money >= tile.price) {
+      const buy = confirm(`${player.name}: ${translations[lang].buy} ${tile.name[lang]} for ${tile.price}?`);
+      if (buy) {
+        player.money -= tile.price;
+        tile.owner = player.id;
+        player.properties.push(tile.id);
+        renderLog(`${player.name} buys ${tile.name[lang]} for ${tile.price}`);
+      } else {
+        startAuction(tile);
+      }
+    } else {
+      startAuction(tile);
+    }
+  } else if (tile.owner !== player.id) {
+    let rent = tile.rent;
+    if (tile.residence) rent *= 2;
+    rent *= modifiers.rent;
+    rent = Math.round(rent);
+    const owner = players.find(p => p.id === tile.owner);
+    player.money -= rent;
+    owner.money += rent;
+    renderLog(`${player.name} ${translations[lang].payRent} ${rent} to ${owner.name}`);
+  } else {
+    if (canBuildResidence(player, tile)) {
+      buildBtn.style.display = 'block';
+      buildBtn.textContent = translations[lang].build + ` (${tile.residenceCost})`;
+    }
+  }
+}
+
+// move player token and apply tile effect
+function movePlayer(player, steps) {
+  if (modifiers.movement !== null) {
+    steps = Math.min(steps, modifiers.movement);
+  }
+  player.position = (player.position + steps) % boardTiles.length;
+  const tile = boardTiles[player.position];
+  handleTile(player, tile);
+}
+
+// main action: roll dice and move token
+document.getElementById('roll').addEventListener('click', () => {
+  const player = players[currentPlayerIndex];
+  applyRandomEvent();
+  const roll = rollDice();
+  renderLog(`${player.name} rolls ${roll}`);
+  movePlayer(player, roll);
+  renderBoard();
+  nextTurn();
+});
+
+// initial render
+renderBoard();
+renderLog('Game started');


### PR DESCRIPTION
## Summary
- document features and usage
- expand board data with more cities, chance cards, random events and players
- implement random economic/weather events, property auctions and residence construction doubling rent
- add build button and adjust styles for new controls

## Testing
- `npm test` *(fails: package.json missing)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865aa94f42083209e66ca46776344a2