### PR TITLE
Prevent jail move cards from granting start bonus

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -403,6 +403,7 @@ const CONFIG = {
             id: 4,
             type: 'move',
             target: 9,
+            collectMoney: false,
             text: 'Отправляйтесь в тюрьму',
             en_text: 'Go to jail'
         },

--- a/js/game.js
+++ b/js/game.js
@@ -443,7 +443,7 @@ class Game {
                 }
                 break;
             case 'move':
-                player.moveToPosition(card.target, true);
+                player.moveToPosition(card.target, card.collectMoney !== false);
                 this.handleCellLanding(player, player.position);
                 break;
         }

--- a/server/gameInstance.js
+++ b/server/gameInstance.js
@@ -275,7 +275,7 @@ export class GameInstance {
 
             case 'move':
                 const oldPos = player.position;
-                const passedGo = player.moveToPosition(card.target, true);
+                const passedGo = player.moveToPosition(card.target, card.collectMoney !== false);
 
                 if (passedGo) {
                     this.addChatMessage('system', `${player.name} прошел СТАРТ и получил ${CONFIG.GAME.STARTING_MONEY / 10}.`);


### PR DESCRIPTION
## Summary
- respect a card's collectMoney flag when moving players on the client and server so chance effects can suppress start payouts
- mark the "Go to jail" chance card to skip awarding the start reward while keeping other movement cards unchanged

## Testing
- npm test -- player.test.js *(fails: TypeError: Cannot read properties of undefined (reading 'extend') due to Jest/expect dependency mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68f1582a6554832083e82044ae919069