### PR TITLE
Add Hype Sprint viral multiplayer mini-game

### DIFF
--- a/apps/viral-party/game.js
+++ b/apps/viral-party/game.js
@@ -1,0 +1,266 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import {
+  getFirestore,
+  doc,
+  setDoc,
+  getDoc,
+  onSnapshot,
+  updateDoc,
+  serverTimestamp,
+  query,
+  orderBy,
+  limit,
+  collection
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+
+const firebaseConfig = {
+  apiKey: 'REPLACE_ME',
+  authDomain: 'REPLACE_ME.firebaseapp.com',
+  projectId: 'REPLACE_ME',
+  storageBucket: 'REPLACE_ME.appspot.com',
+  messagingSenderId: 'REPLACE_ME',
+  appId: 'REPLACE_ME',
+};
+
+const ui = {
+  createRoom: document.getElementById('create-room'),
+  joinRoom: document.getElementById('join-room'),
+  joinForm: document.getElementById('join-form'),
+  roomInput: document.getElementById('room-input'),
+  confirmJoin: document.getElementById('confirm-join'),
+  name: document.getElementById('name-input'),
+  boost: document.getElementById('boost-input'),
+  presence: document.getElementById('presence-indicator'),
+  roomTitle: document.getElementById('room-title'),
+  roomCode: document.getElementById('room-code'),
+  onlineCount: document.getElementById('online-count'),
+  roundTimer: document.getElementById('round-timer'),
+  status: document.getElementById('status-bar'),
+  leaderboard: document.getElementById('leaderboard'),
+  tap: document.getElementById('tap-btn'),
+  progress: document.getElementById('progress-bar'),
+  pps: document.getElementById('pps'),
+  copy: document.getElementById('copy-code'),
+  reset: document.getElementById('reset-local'),
+  feed: document.getElementById('live-feed')
+};
+
+const DEMO_KEY = 'hype-sprint-demo';
+let firebaseEnabled = false;
+let db;
+let unsubscribeRoom;
+
+const state = {
+  roomId: 'DEMO',
+  nickname: 'Гость',
+  clicks: 0,
+  history: [],
+  combo: 0,
+  feed: []
+};
+
+function initFirebase() {
+  if (!firebaseConfig.apiKey || firebaseConfig.apiKey === 'REPLACE_ME') return;
+  try {
+    const app = initializeApp(firebaseConfig);
+    db = getFirestore(app);
+    firebaseEnabled = true;
+    ui.presence.textContent = 'Онлайн режим';
+    logFeed('Firebase подключён. Создавайте приватные комнаты.');
+  } catch (err) {
+    console.error(err);
+    firebaseEnabled = false;
+    ui.presence.textContent = 'Оффлайн демо';
+    logFeed('Firebase не настроен. Доступен демо‑режим.');
+  }
+}
+
+function randomRoom() {
+  return `ROOM-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+}
+
+function hydrateLocal() {
+  const saved = localStorage.getItem(DEMO_KEY);
+  if (!saved) return;
+  const parsed = JSON.parse(saved);
+  Object.assign(state, parsed);
+}
+
+function persistLocal() {
+  localStorage.setItem(DEMO_KEY, JSON.stringify({
+    roomId: state.roomId,
+    nickname: state.nickname,
+    clicks: state.clicks,
+    combo: state.combo,
+    feed: state.feed.slice(-20)
+  }));
+}
+
+function setStatus(message, type = 'success') {
+  ui.status.textContent = message;
+  ui.status.style.background = type === 'error' ? 'rgba(249, 115, 22, 0.08)' : 'rgba(34, 197, 94, 0.08)';
+  ui.status.style.color = type === 'error' ? '#fb923c' : '#22c55e';
+  ui.status.style.borderColor = type === 'error' ? 'rgba(249, 115, 22, 0.3)' : 'rgba(34, 197, 94, 0.24)';
+}
+
+function logFeed(message) {
+  const entry = `${new Date().toLocaleTimeString()} — ${message}`;
+  state.feed.unshift(entry);
+  state.feed = state.feed.slice(0, 12);
+  ui.feed.innerHTML = state.feed.map((item) => `<div><strong>Событие</strong> ${item}</div>`).join('');
+}
+
+function renderLeaderboard(scores) {
+  const sorted = [...scores].sort((a, b) => b.clicks - a.clicks).slice(0, 10);
+  ui.leaderboard.innerHTML = sorted
+    .map((player, index) => {
+      const badgeClass = index === 0 ? 'gold' : index === 1 ? 'silver' : index === 2 ? 'bronze' : '';
+      const badge = `<span class="badge ${badgeClass}">${index + 1}</span>`;
+      const boost = player.boost ? `<span class="pill">x${player.boost}</span>` : '';
+      return `<li>${badge}<div><strong>${player.name}</strong><div class="tiny">${player.room}</div></div><div>${player.clicks} ⚡ ${boost}</div></li>`;
+    })
+    .join('');
+}
+
+function updatePps() {
+  const now = Date.now();
+  state.history = state.history.filter((ts) => now - ts < 4000);
+  const perSecond = state.history.length / 4;
+  ui.pps.textContent = `${perSecond.toFixed(1)} кликов/с`;
+}
+
+async function syncRoom(clickDelta = 0) {
+  if (!firebaseEnabled || !db) return;
+  const roomRef = doc(db, 'hype-rooms', state.roomId);
+  const snapshot = await getDoc(roomRef);
+  if (!snapshot.exists()) {
+    await setDoc(roomRef, {
+      createdAt: serverTimestamp(),
+      roundEndsAt: null,
+      online: 1,
+      lastPing: serverTimestamp()
+    });
+  } else if (clickDelta === 0) {
+    await updateDoc(roomRef, { lastPing: serverTimestamp() });
+  }
+
+  const playerRef = doc(db, 'hype-rooms', state.roomId, 'players', state.nickname);
+  await setDoc(playerRef, {
+    name: state.nickname,
+    clicks: state.clicks,
+    boost: boostMultiplier(),
+    updatedAt: serverTimestamp()
+  }, { merge: true });
+}
+
+function boostMultiplier() {
+  const boost = ui.boost.value.trim();
+  if (!boost) return 1;
+  return 1 + Math.min(1, boost.length / 20);
+}
+
+function updateLocalScores() {
+  const demoScores = JSON.parse(localStorage.getItem(`${DEMO_KEY}-scores`) || '[]');
+  const existing = demoScores.find((s) => s.name === state.nickname);
+  if (existing) {
+    existing.clicks = state.clicks;
+    existing.boost = boostMultiplier();
+  } else {
+    demoScores.push({ name: state.nickname, clicks: state.clicks, room: state.roomId, boost: boostMultiplier() });
+  }
+  localStorage.setItem(`${DEMO_KEY}-scores`, JSON.stringify(demoScores));
+  renderLeaderboard(demoScores);
+}
+
+function tap() {
+  const boost = boostMultiplier();
+  state.clicks += 1 * boost;
+  state.combo = (state.combo + 1) % 20;
+  state.history.push(Date.now());
+  const progress = (state.combo / 20) * 100;
+  ui.progress.style.width = `${progress}%`;
+  if (state.combo === 0) {
+    state.clicks += 10 * boost;
+    setStatus('Комбо! +10 клик‑монет', 'success');
+    logFeed(`${state.nickname} активировал комбо в комнате ${state.roomId}`);
+  }
+  ui.tap.textContent = `⚡ ${Math.floor(state.clicks)} монет`;
+  updatePps();
+  updateLocalScores();
+  syncRoom(1);
+  persistLocal();
+}
+
+function bindRoomRealtime() {
+  if (!firebaseEnabled || !db) return;
+  if (unsubscribeRoom) unsubscribeRoom();
+  const roomRef = collection(db, 'hype-rooms', state.roomId, 'players');
+  unsubscribeRoom = onSnapshot(query(roomRef, orderBy('clicks', 'desc'), limit(20)), (snap) => {
+    const scores = snap.docs.map((doc) => doc.data());
+    renderLeaderboard(scores);
+    ui.onlineCount.textContent = scores.length.toString();
+  });
+}
+
+function copyCode() {
+  if (!state.roomId) return;
+  navigator.clipboard.writeText(state.roomId).then(() => setStatus('Код скопирован, зовите друзей!'));
+}
+
+function resetDemo() {
+  localStorage.removeItem(DEMO_KEY);
+  localStorage.removeItem(`${DEMO_KEY}-scores`);
+  Object.assign(state, { roomId: 'DEMO', clicks: 0, combo: 0, feed: [] });
+  ui.tap.textContent = '⚡ Блиц‑клик';
+  ui.progress.style.width = '0%';
+  renderLeaderboard([]);
+  setStatus('Демо сброшено. Начните заново!');
+}
+
+function joinRoom(roomId) {
+  state.roomId = roomId || randomRoom();
+  ui.roomCode.textContent = state.roomId;
+  ui.roomTitle.textContent = state.roomId === 'DEMO' ? 'Демо режим' : `Комната ${state.roomId}`;
+  ui.roundTimer.textContent = '90 сек';
+  logFeed(`Присоединились к комнате ${state.roomId}`);
+  bindRoomRealtime();
+  syncRoom();
+  persistLocal();
+}
+
+function bindUI() {
+  ui.tap.addEventListener('click', tap);
+  ui.createRoom.addEventListener('click', () => joinRoom(randomRoom()));
+  ui.joinRoom.addEventListener('click', () => ui.joinForm.toggleAttribute('hidden'));
+  ui.confirmJoin.addEventListener('click', () => {
+    const code = ui.roomInput.value.trim().toUpperCase();
+    if (!code) return setStatus('Введите код комнаты', 'error');
+    joinRoom(code);
+  });
+  ui.copy.addEventListener('click', copyCode);
+  ui.reset.addEventListener('click', resetDemo);
+  ui.name.addEventListener('input', (e) => {
+    state.nickname = e.target.value || 'Гость';
+    syncRoom();
+    persistLocal();
+  });
+  ui.boost.addEventListener('input', () => {
+    updateLocalScores();
+    syncRoom();
+  });
+}
+
+function bootstrap() {
+  hydrateLocal();
+  ui.name.value = state.nickname;
+  ui.roomCode.textContent = state.roomId;
+  ui.roomTitle.textContent = state.roomId === 'DEMO' ? 'Демо режим' : `Комната ${state.roomId}`;
+  ui.tap.textContent = state.clicks ? `⚡ ${Math.floor(state.clicks)} монет` : '⚡ Блиц‑клик';
+  renderLeaderboard(JSON.parse(localStorage.getItem(`${DEMO_KEY}-scores`) || '[]'));
+  bindUI();
+  initFirebase();
+  joinRoom(state.roomId);
+  setInterval(updatePps, 800);
+}
+
+bootstrap();

--- a/apps/viral-party/index.html
+++ b/apps/viral-party/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hype Sprint — вирусная мультиплеерная мини‑игра</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Real‑time • Mobile‑first • Invite‑only</p>
+        <h1>Hype Sprint</h1>
+        <p class="lede">
+          Быстрая кооперативная гонка кликов: собирайте монеты, врывайтесь в лидерборд и получайте бонусы за приглашения.
+          Работает с Firebase или в оффлайне для демо.
+        </p>
+        <div class="cta-row">
+          <button id="create-room" class="btn primary">Создать комнату</button>
+          <button id="join-room" class="btn ghost">Войти по коду</button>
+          <div class="pill" id="presence-indicator">Оффлайн демо</div>
+        </div>
+      </div>
+      <div class="ticker" id="live-feed" aria-live="polite"></div>
+    </header>
+
+    <main class="layout">
+      <section class="panel">
+        <div class="panel__header">
+          <div>
+            <p class="eyebrow">Комната</p>
+            <h2 id="room-title">Демо режим</h2>
+          </div>
+          <button class="btn icon" id="copy-code" title="Скопировать код комнаты">📋</button>
+        </div>
+        <div class="room-meta">
+          <div>
+            <p class="meta-label">Код</p>
+            <p class="meta-value" id="room-code">—</p>
+          </div>
+          <div>
+            <p class="meta-label">Игроков онлайн</p>
+            <p class="meta-value" id="online-count">1</p>
+          </div>
+          <div>
+            <p class="meta-label">Сражение</p>
+            <p class="meta-value" id="round-timer">∞</p>
+          </div>
+        </div>
+        <div class="input-group" id="join-form" hidden>
+          <label for="room-input">Введите код</label>
+          <div class="input-row">
+            <input id="room-input" placeholder="Например, RUSH42" maxlength="12" />
+            <button class="btn primary" id="confirm-join">Войти</button>
+          </div>
+        </div>
+        <div class="input-group">
+          <label for="name-input">Никнейм</label>
+          <input id="name-input" placeholder="Ваш ник" maxlength="16" />
+        </div>
+        <div class="input-group">
+          <label for="boost-input">Инвайт‑бонус</label>
+          <input id="boost-input" placeholder="Ссылка‑приманка (любой текст)" />
+        </div>
+        <div class="status" id="status-bar">Готовы к старту! Нажимайте, чтобы фармить монеты.</div>
+      </section>
+
+      <section class="panel scoreboard">
+        <div class="panel__header">
+          <div>
+            <p class="eyebrow">Лидерборд</p>
+            <h2>Топ за раунд</h2>
+          </div>
+          <button class="btn ghost" id="reset-local">Сбросить демо</button>
+        </div>
+        <ol id="leaderboard" class="board"></ol>
+      </section>
+
+      <section class="panel action">
+        <div class="panel__header">
+          <div>
+            <p class="eyebrow">Фарм</p>
+            <h2>Спамьте клики</h2>
+          </div>
+          <div class="pill" id="pps">0.0 кликов/с</div>
+        </div>
+        <button id="tap-btn" class="tap-btn">⚡ Блиц‑клик</button>
+        <div class="progress">
+          <div id="progress-bar" class="progress__bar"></div>
+        </div>
+        <p class="hint">Каждые 20 кликов — «Комбо» x2. Делитесь кодом, чтобы получить буст.</p>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="game.js"></script>
+</body>
+</html>

--- a/apps/viral-party/styles.css
+++ b/apps/viral-party/styles.css
@@ -1,0 +1,199 @@
+:root {
+  --bg: #050915;
+  --panel: #0d1426;
+  --panel-contrast: #0f1a31;
+  --text: #f7f9ff;
+  --muted: #9aa7c7;
+  --accent: #5eead4;
+  --accent-2: #c084fc;
+  --danger: #f97316;
+  --success: #22c55e;
+  --shadow: 0 20px 80px rgba(0, 0, 0, 0.35);
+  --radius: 18px;
+  --gap: 20px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(94, 234, 212, 0.12), transparent 30%),
+    radial-gradient(circle at 80% 0%, rgba(192, 132, 252, 0.14), transparent 30%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 24px;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: 42px;
+  margin: 8px 0 12px;
+}
+
+.lede { color: var(--muted); max-width: 720px; }
+
+.eyebrow {
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+  align-items: center;
+}
+
+.btn {
+  border: none;
+  padding: 12px 18px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+  color: #0b1224;
+}
+
+.btn.primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #0b1224; }
+.btn.ghost { background: transparent; border: 1px solid rgba(255,255,255,0.12); color: var(--text); }
+.btn.icon { width: 42px; height: 42px; padding: 0; font-size: 18px; }
+.btn:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
+.btn:active { transform: translateY(0); }
+
+.pill {
+  background: rgba(255,255,255,0.08);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.layout { display: grid; grid-template-columns: 1.1fr 0.9fr 0.9fr; gap: var(--gap); }
+
+.panel {
+  background: linear-gradient(180deg, var(--panel), var(--panel-contrast));
+  border: 1px solid rgba(255,255,255,0.06);
+  box-shadow: var(--shadow);
+  border-radius: var(--radius);
+  padding: 18px 18px 20px;
+  min-height: 320px;
+}
+
+.panel__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.panel h2 { margin: 6px 0; }
+
+.room-meta { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin: 14px 0 8px; }
+.meta-label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+.meta-value { font-size: 20px; font-weight: 700; }
+
+.input-group { display: grid; gap: 8px; margin-top: 12px; }
+.input-group label { color: var(--muted); font-weight: 600; }
+.input-group input {
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.03);
+  color: var(--text);
+  font-size: 15px;
+}
+
+.input-row { display: flex; gap: 8px; }
+
+.status {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(34, 197, 94, 0.08);
+  color: var(--success);
+  border: 1px solid rgba(34, 197, 94, 0.24);
+}
+
+.scoreboard .board {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 10px;
+}
+
+.board li {
+  background: rgba(255,255,255,0.04);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.badge { padding: 6px 10px; border-radius: 999px; font-weight: 700; }
+.badge.gold { background: linear-gradient(135deg, #facc15, #f97316); color: #0b1224; }
+.badge.silver { background: linear-gradient(135deg, #e5e7eb, #9ca3af); color: #0b1224; }
+.badge.bronze { background: linear-gradient(135deg, #f59e0b, #b45309); color: #0b1224; }
+
+.action { text-align: center; }
+.tap-btn {
+  width: 100%;
+  padding: 24px;
+  font-size: 22px;
+  font-weight: 800;
+  border-radius: var(--radius);
+  border: none;
+  background: radial-gradient(circle at 30% 20%, rgba(94, 234, 212, 0.4), transparent 35%),
+    linear-gradient(135deg, #22d3ee, #c084fc);
+  color: #0b1224;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  transition: transform 0.08s ease, filter 0.12s ease;
+}
+.tap-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
+.tap-btn:active { transform: translateY(0); }
+
+.progress { width: 100%; height: 12px; border-radius: 999px; background: rgba(255,255,255,0.06); margin: 16px 0 8px; }
+.progress__bar { height: 100%; width: 0%; border-radius: inherit; background: linear-gradient(135deg, var(--accent), var(--accent-2)); transition: width 0.12s ease; }
+
+.hint { color: var(--muted); margin-top: 8px; }
+
+.ticker {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: var(--radius);
+  padding: 12px;
+  min-height: 140px;
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.ticker strong { color: var(--text); }
+
+@media (max-width: 960px) {
+  .layout { grid-template-columns: 1fr; }
+  .hero { grid-template-columns: 1fr; }
+  .panel { min-height: auto; }
+}
+
+.tiny {
+  color: var(--muted);
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- add Hype Sprint multiplayer click-race mini-game with Firebase-ready logic and offline demo
- include responsive UI/UX, leaderboard, and presence indicators
- provide styling and copyable room codes for viral invites

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b98857b488320bc49e390e7df3a85)