### PR TITLE
Исправлена очистка object URL для загруженных изображений

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -158,8 +158,8 @@ renderAll();
 
 uploadInput.addEventListener('change', handleUpload);
 demoButton.addEventListener('click', () => {
+  revokeObjectUrl();
   photoElement.src = demoFaceUrl;
-  delete photoElement.dataset.objectUrl;
   state.hintDismissed = false;
   stageHint.classList.remove('is-hidden');
   setStatus('Загружено демонстрационное фото.', 'success');
@@ -188,6 +188,7 @@ stageInner.addEventListener('pointerleave', () => {
 
 photoElement.addEventListener('load', handlePhotoLoad);
 photoElement.addEventListener('error', () => {
+  revokeObjectUrl();
   setStatus('Не удалось загрузить изображение. Попробуйте другой файл.', 'warning');
 });
 
@@ -591,6 +592,7 @@ function handleUpload(event) {
     return;
   }
 
+  revokeObjectUrl();
   const objectUrl = URL.createObjectURL(file);
   photoElement.src = objectUrl;
   photoElement.dataset.objectUrl = objectUrl;
@@ -609,8 +611,7 @@ function handlePhotoLoad() {
   }
 
   if (photoElement.dataset.objectUrl) {
-    URL.revokeObjectURL(photoElement.dataset.objectUrl);
-    delete photoElement.dataset.objectUrl;
+    revokeObjectUrl();
   }
 
   renderAll();
@@ -710,6 +711,16 @@ function applyTemplateDefaults(template) {
   state.exposure = defaults.exposure;
   state.offset = { ...defaults.offset };
   state.variantId = defaults.variantId;
+}
+
+function revokeObjectUrl() {
+  const objectUrl = photoElement.dataset.objectUrl;
+  if (!objectUrl) {
+    return;
+  }
+
+  URL.revokeObjectURL(objectUrl);
+  delete photoElement.dataset.objectUrl;
 }
 
 function createTemplateDefaults(template) {


### PR DESCRIPTION
### Motivation
- Избежать утечек памяти при смене изображения за счёт неотозванных `object URL`.
- Обеспечить корректную отработку при переключении на демонстрационное фото и при загрузке нового файла.
- Свести воедино логику отзыва URL, чтобы избежать дублирующегося кода и пропусков очистки.
- Устранить возможные оставшиеся `dataset.objectUrl` на `photoElement` после ошибок загрузки.

### Description
- Добавлена вспомогательная функция `revokeObjectUrl()` для централизованного отзыва и удаления `photoElement.dataset.objectUrl`.
- Вызов `revokeObjectUrl()` добавлен в обработчики: кнопки демо (`demoButton`), загрузки файла (`handleUpload`), обработчика ошибок изображения и после успешной загрузки в `handlePhotoLoad`.
- Удалены прямые вызовы `URL.revokeObjectURL(...)` и ручные `delete photoElement.dataset.objectUrl` в пользу единообразного хелпера.
- Поведение приложения не изменилось, изменения направлены на безопасность и предотвращение утечек ресурсов.

### Testing
- Автоматические тесты не запускались.
- Линтер не запускался автоматически.
- Внесённые изменения покрыты ручным просмотром патча и интеграцией в существующий код.
- Нет сообщений об ошибках при сборке после изменений.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce52d74908320a0143a09b254e923)