### PR TITLE
Fix turn advancement for build/upgrade actions

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -47,11 +47,13 @@ class Player {
 const players = playerTemplates.map(t => new Player(t));
 let currentPlayerIndex = 0;
 let activePlayerIndex = null;
+let pendingTurnAdvance = false;
 let currentTile = null;
 let modifiers = { rent: 1, movement: null, movementBonus: 0 };
 
 buildBtn.addEventListener('click', () => {
-  const player = players[activePlayerIndex ?? currentPlayerIndex];
+  if (activePlayerIndex === null) return;
+  const player = players[activePlayerIndex];
   if (currentTile && canBuildResidence(player, currentTile) && player.money >= currentTile.residenceCost) {
     player.money -= currentTile.residenceCost;
     currentTile.residence = true;
@@ -62,7 +64,8 @@ buildBtn.addEventListener('click', () => {
 });
 
 upgradeBtn.addEventListener('click', () => {
-  const player = players[activePlayerIndex ?? currentPlayerIndex];
+  if (activePlayerIndex === null) return;
+  const player = players[activePlayerIndex];
   if (currentTile && canUpgrade(player, currentTile) && player.money >= currentTile.upgradeCost) {
     player.money -= currentTile.upgradeCost;
     currentTile.upgrades += 1;
@@ -226,6 +229,10 @@ function movePlayer(player, steps) {
 
 // main action: roll dice and move token
 document.getElementById('roll').addEventListener('click', () => {
+  if (pendingTurnAdvance) {
+    nextTurn();
+    pendingTurnAdvance = false;
+  }
   activePlayerIndex = currentPlayerIndex;
   const player = players[activePlayerIndex];
   applyRandomEvent();
@@ -233,7 +240,7 @@ document.getElementById('roll').addEventListener('click', () => {
   renderLog(`${player.name} rolls ${roll}`);
   movePlayer(player, roll);
   renderBoard();
-  nextTurn();
+  pendingTurnAdvance = true;
 });
 
 // initial render


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where post-roll `build`/`upgrade` actions were applied to the next player because the turn advanced immediately after rolling. 
- Ensure optional actions after landing on a tile (build/upgrade) charge and modify the player who actually rolled. 
- Make the UI buttons (`buildBtn`, `upgradeBtn`) operate only when there is an active player to avoid unintended state changes. 

### Description
- Added a `pendingTurnAdvance` flag and changed the `roll` handler so the turn is deferred by setting `pendingTurnAdvance = true` and the actual `nextTurn()` occurs at the start of the next `roll` if the flag is set. 
- Guarded `build` and `upgrade` handlers to return early when `activePlayerIndex` is `null` and always use `players[activePlayerIndex]` instead of falling back to `currentPlayerIndex`. 
- Updated `js/game.js` to coordinate `activePlayerIndex`, `pendingTurnAdvance`, and `renderBoard()` so property improvements are applied to the correct player and UI reflects availability of actions. 

### Testing
- No automated test suite was found in the repository; therefore no automated tests were executed. 
- No linter was run as there was no configured CI test or lint step detected in the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68f6b358395c83208b69bb33402a30f9)