### PR TITLE
Move HomeScreen strings/state into view-model and add i18n/profile states

### DIFF
--- a/apps/calorie-tracker/src/hooks/useDashboardViewModel.ts
+++ b/apps/calorie-tracker/src/hooks/useDashboardViewModel.ts
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import { useMealLog } from './useMealLog';
+
+const dictionary = {
+  ru: {
+    greeting: (name: string) => `Привет, ${name} 👋`,
+    greetingFallback: 'Привет 👋',
+    subtitle: (goalCalories: number) =>
+      `Сделайте фото блюда или добавьте вручную. Мы посчитаем КБЖУ и поможем удерживать цель ${goalCalories} ккал.`,
+    loadingProfile: 'Загружаем профиль…',
+    emptyProfile: 'Профиль не заполнен. Добавьте имя и цель калорий.',
+    streakLabel: (streakDays: number) => `Серия: ${streakDays} дн.`,
+    today: 'Сегодня',
+    emptyMeals: 'Пока нет приёмов пищи за сегодня.',
+  },
+  en: {
+    greeting: (name: string) => `Hi, ${name} 👋`,
+    greetingFallback: 'Hi 👋',
+    subtitle: (goalCalories: number) =>
+      `Take a meal photo or add it manually. We will calculate macros and help you stay on your ${goalCalories} kcal goal.`,
+    loadingProfile: 'Loading profile…',
+    emptyProfile: 'Profile is empty. Add your name and calorie goal.',
+    streakLabel: (streakDays: number) => `Streak: ${streakDays} days`,
+    today: 'Today',
+    emptyMeals: 'No meals logged for today yet.',
+  },
+};
+
+type SupportedLocale = keyof typeof dictionary;
+
+const resolveLocale = (): SupportedLocale => {
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale.toLowerCase();
+
+  if (locale.startsWith('ru')) {
+    return 'ru';
+  }
+
+  return 'en';
+};
+
+export const useDashboardViewModel = () => {
+  const { meals, totals, addMeal, profile, streakDays, calorieGoal, isProfileLoading } = useMealLog();
+
+  const locale = resolveLocale();
+  const t = dictionary[locale];
+
+  const target = useMemo(
+    () => ({
+      calories: calorieGoal,
+      protein: profile?.macroGoal.protein ?? 140,
+      carbs: profile?.macroGoal.carbs ?? 220,
+      fat: profile?.macroGoal.fat ?? 70,
+    }),
+    [calorieGoal, profile?.macroGoal.carbs, profile?.macroGoal.fat, profile?.macroGoal.protein]
+  );
+
+  return {
+    meals,
+    totals,
+    target,
+    addMeal,
+    isProfileLoading,
+    isProfileEmpty: !isProfileLoading && !profile,
+    greeting: profile ? t.greeting(profile.name) : t.greetingFallback,
+    subtitle: t.subtitle(calorieGoal),
+    streakLabel: t.streakLabel(streakDays),
+    todayLabel: t.today,
+    emptyMealsLabel: t.emptyMeals,
+    loadingProfileLabel: t.loadingProfile,
+    emptyProfileLabel: t.emptyProfile,
+  };
+};

--- a/apps/calorie-tracker/src/hooks/useMealLog.ts
+++ b/apps/calorie-tracker/src/hooks/useMealLog.ts
@@ -1,4 +1,4 @@
-import { useMemo, useReducer } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import type { MacroBreakdown, MealEntry, MealType } from '../types/meal';
 
 const initialMeals: MealEntry[] = [
@@ -53,6 +53,17 @@ const initialMeals: MealEntry[] = [
   },
 ];
 
+const profileState = {
+  name: 'Анна',
+  calorieGoal: 2100,
+  streakDays: 5,
+  macroGoal: {
+    protein: 140,
+    carbs: 220,
+    fat: 70,
+  },
+};
+
 const createId = () => `meal-${Math.random().toString(36).slice(2, 9)}`;
 
 type AddMealPayload = {
@@ -97,6 +108,17 @@ const sumMacros = (entries: MealEntry[]): MacroBreakdown =>
 
 export const useMealLog = () => {
   const [meals, dispatch] = useReducer(mealReducer, initialMeals);
+  const [profile, setProfile] = useState<typeof profileState | null>(null);
+  const [isProfileLoading, setProfileLoading] = useState(true);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setProfile(profileState);
+      setProfileLoading(false);
+    }, 250);
+
+    return () => clearTimeout(timerId);
+  }, []);
 
   const totals = useMemo(() => sumMacros(meals), [meals]);
 
@@ -124,6 +146,10 @@ export const useMealLog = () => {
     totals,
     addMeal,
     groupedByType,
+    profile,
+    isProfileLoading,
+    calorieGoal: profile?.calorieGoal ?? 2100,
+    streakDays: profile?.streakDays ?? 0,
   };
 };
 

--- a/apps/calorie-tracker/src/screens/HomeScreen.tsx
+++ b/apps/calorie-tracker/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import {
+  ActivityIndicator,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -10,27 +11,51 @@ import {
 import { AddMealSheet } from '../components/AddMealSheet';
 import { MealCard } from '../components/MealCard';
 import { NutritionSummary } from '../components/NutritionSummary';
-import { useMealLog } from '../hooks/useMealLog';
+import { useDashboardViewModel } from '../hooks/useDashboardViewModel';
 import { palette, radius, spacing } from '../theme/colors';
 
 export const HomeScreen = () => {
-  const { meals, totals, addMeal } = useMealLog();
+  const {
+    meals,
+    totals,
+    target,
+    addMeal,
+    greeting,
+    subtitle,
+    streakLabel,
+    todayLabel,
+    emptyMealsLabel,
+    isProfileLoading,
+    isProfileEmpty,
+    loadingProfileLabel,
+    emptyProfileLabel,
+  } = useDashboardViewModel();
   const [isSheetOpen, setSheetOpen] = useState(false);
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.greeting}>Привет, Анна 👋</Text>
-        <Text style={styles.subtitle}>
-          Сделайте фото блюда или добавьте вручную. Мы посчитаем КБЖУ и поможем
-          удерживать цель.
-        </Text>
-        <NutritionSummary totals={totals} />
+        <Text style={styles.greeting}>{greeting}</Text>
+
+        {isProfileLoading ? (
+          <View style={styles.profileStateRow}>
+            <ActivityIndicator color={palette.primary} />
+            <Text style={styles.profileStateText}>{loadingProfileLabel}</Text>
+          </View>
+        ) : null}
+
+        {isProfileEmpty ? <Text style={styles.profileStateText}>{emptyProfileLabel}</Text> : null}
+
+        <Text style={styles.subtitle}>{subtitle}</Text>
+        <Text style={styles.streak}>{streakLabel}</Text>
+        <NutritionSummary totals={totals} target={target} />
         <View>
-          <Text style={styles.sectionTitle}>Сегодня</Text>
-          {meals.map((meal) => (
-            <MealCard key={meal.id} meal={meal} />
-          ))}
+          <Text style={styles.sectionTitle}>{todayLabel}</Text>
+          {meals.length ? (
+            meals.map((meal) => <MealCard key={meal.id} meal={meal} />)
+          ) : (
+            <Text style={styles.emptyMeals}>{emptyMealsLabel}</Text>
+          )}
         </View>
       </ScrollView>
       <Pressable
@@ -82,13 +107,34 @@ const styles = StyleSheet.create({
     color: palette.textMuted,
     fontSize: 16,
     lineHeight: 22,
+    marginBottom: spacing.sm,
+  },
+  streak: {
+    color: palette.primary,
+    fontSize: 15,
+    fontWeight: '600',
     marginBottom: spacing.lg,
+  },
+  profileStateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  profileStateText: {
+    color: palette.textMuted,
+    fontSize: 14,
+    marginBottom: spacing.sm,
   },
   sectionTitle: {
     color: palette.text,
     fontSize: 18,
     fontWeight: '600',
     marginBottom: spacing.md,
+  },
+  emptyMeals: {
+    color: palette.textMuted,
+    fontSize: 15,
   },
   fab: {
     position: 'absolute',


### PR DESCRIPTION
### Motivation
- Remove hardcoded UI text from `HomeScreen` and centralize localization in a single view‑model with RU/EN support. 
- Surface real dashboard data (`totals`, calorie goal, streak, profile) and add explicit loading/empty profile states so the UI can react to profile availability.

### Description
- Added `useDashboardViewModel` (`apps/calorie-tracker/src/hooks/useDashboardViewModel.ts`) providing a RU/EN dictionary, locale resolution, computed `greeting`, `subtitle`, `todayLabel`, `emptyMealsLabel`, `streakLabel`, `loadingProfileLabel`, `emptyProfileLabel`, and `target` macros.
- Extended `useMealLog` (`apps/calorie-tracker/src/hooks/useMealLog.ts`) to expose `profile`, `isProfileLoading`, `calorieGoal`, and `streakDays` (simulated seed profile + small loading delay) used by the dashboard view-model.
- Updated `HomeScreen` (`apps/calorie-tracker/src/screens/HomeScreen.tsx`) to consume `useDashboardViewModel`, remove hardcoded strings, display profile loading/empty-profile UI, show `streak`, and pass `target` into `NutritionSummary`.
- Kept UI layout and behavior intact while moving all user-facing strings into the dictionary and wiring state-driven values.

### Testing
- Ran lint: `cd apps/calorie-tracker && npm run lint` — succeeded.
- Type check: `cd apps/calorie-tracker && npx tsc --noEmit` — failed due to pre-existing TypeScript errors referencing `process` in `src/services/mealRecognition.ts`, unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d935b65acc83209f421ee0ee33c8b5)