### PR TITLE
docs: add portfolio control register

### DIFF
--- a/docs/PORTFOLIO_CONTROL_REGISTER.md
+++ b/docs/PORTFOLIO_CONTROL_REGISTER.md
@@ -1,0 +1,65 @@
+# GitHub Portfolio Control Register
+
+> Updated: 11 August 2026  
+> Owner: Jokersochi  
+> Control issue: [#57](https://github.com/Jokersochi/Jokersochi/issues/57)
+
+This document is the operational register for portfolio cleanup. It does **not** authorize a merge, archive, deletion, deployment, or change of production settings by itself.
+
+## Safety rules
+
+1. Never push directly to `main` / `master`.
+2. One task, one branch, one PR.
+3. A repository may be deleted only after a source/upstream comparison, branch/PR/issue/deployment/dependency check, and a recovery reference.
+4. A repository with product code, custom commits, user-facing URLs, releases, packages, or unresolved provenance is `KEEP`, `EXTRACT`, or `QUARANTINE` — not `DELETE`.
+5. A failed deployment is diagnosed from its own logs; application code is not changed merely to satisfy a stale hosting project.
+6. No secret, token, database URL, or personal data is stored in this register.
+
+## Current portfolio snapshot
+
+| Metric | Verified state |
+|---|---:|
+| Repositories | 34 |
+| Public / private | 24 / 10 |
+| Archived repositories | 0 |
+| Open pull requests | at least 251 |
+| Main PR fan-out | Wan2.2 ≥100; russian-monopoly-local 90; `-` 52 |
+
+The detailed fork decision record lives in [#58](https://github.com/Jokersochi/Jokersochi/issues/58). Product extraction is governed by [#59](https://github.com/Jokersochi/Jokersochi/issues/59).
+
+## Canonical product decisions
+
+| Product | Canonical repository | Status |
+|---|---|---|
+| RealtyAI | `Jokersochi/ai-realtor` | P0 consolidation: [#28](https://github.com/Jokersochi/ai-realtor/issues/28) |
+| Sentinel Markets AI | `Jokersochi/sentinel-markets-ai` | P0 architecture baseline: [#2](https://github.com/Jokersochi/sentinel-markets-ai/issues/2) |
+| Monopoly | `Jokersochi/monopolylux` (provisional) | P0 source comparison: [#2](https://github.com/Jokersochi/monopolylux/issues/2) |
+| Sochi House | `Jokersochi/SochiHouseApp` | P0 launch/branch audit: [#1](https://github.com/Jokersochi/SochiHouseApp/issues/1) |
+| Profile and governance | `Jokersochi/Jokersochi` | profile/docs/orchestration only |
+
+## P0 execution queue
+
+| Order | Action | Evidence / tracker | State |
+|---:|---|---|---|
+| 1 | Switch SochiHouseApp default branch to `main` | `codex/launch-readiness` has no unique commits and is one commit behind `main`; [#1](https://github.com/Jokersochi/SochiHouseApp/issues/1) | ready; GitHub settings action pending |
+| 2 | Stop PR fan-out and create a disposition register | Wan2.2, russian-monopoly-local, `-` | active audit |
+| 3 | Complete fork forensics and prepare exact deletion manifest | [#58](https://github.com/Jokersochi/Jokersochi/issues/58) | active audit |
+| 4 | Fix Vercel configuration drift for RealtyAI | duplicate Next.js projects and stale Vite project; [#37](https://github.com/Jokersochi/ai-realtor/issues/37) | root cause confirmed |
+| 5 | Reconnect MonopolyLux Vercel project | project currently deploys `Wan2.2`; [#6](https://github.com/Jokersochi/monopolylux/issues/6) | root cause confirmed |
+| 6 | Extract Sentinel Android UX safely | mobile prototype contains client-side provider access and simulated data; [#3](https://github.com/Jokersochi/sentinel-markets-ai/issues/3) | planned |
+| 7 | Consolidate RealtyAI and Monopoly sources | [RealtyAI #28](https://github.com/Jokersochi/ai-realtor/issues/28), [Monopoly #2](https://github.com/Jokersochi/monopolylux/issues/2) | active audit |
+
+## Quarantine rules
+
+The following repositories have ambiguous provenance, unintuitive names, or active PR histories. They cannot enter a deletion manifest before individual evidence is recorded:
+
+- `12345`
+- `---`
+- `-`
+- `https-github.com-hiddify-hiddify-app`
+- `ai-core`
+- all product-bearing forks and sources listed in [#58](https://github.com/Jokersochi/Jokersochi/issues/58)
+
+## Definition of done
+
+Portfolio cleanup is complete only when every repository has a verified lifecycle status, every active product has one canonical home and one tested deployment, the PR backlog has a recorded disposition, and each deletion has a recovery trail.

--- a/docs/portfolio/DELETE_MANIFEST.md
+++ b/docs/portfolio/DELETE_MANIFEST.md
@@ -1,0 +1,39 @@
+# Proven-Clean Fork Deletion Manifest
+
+> Checked: 11 August 2026  
+> Governing issue: [#58](https://github.com/Jokersochi/Jokersochi/issues/58)  
+> Status: deletion candidates only — do not delete through a bulk script.
+
+Each repository below passes the strict safety gate:
+
+- no local commits not present in upstream;
+- no side branches;
+- no open PR or issue;
+- no release, deployment, package or GitHub Pages site;
+- no indexed reference from another Jokersochi repository;
+- exact upstream and recovery commit recorded.
+
+| Repository | Upstream | Recovery reference | Comparison | Verdict |
+|---|---|---|---|---|
+| `Jokersochi/flux` | `black-forest-labs/flux` | `802fb4713906133fcbd0d8dc5351620ca4773036` | main is identical, ahead 0 / behind 0 | DELETE CANDIDATE |
+| `Jokersochi/shellcheck.net` | `koalaman/shellcheck.net` | `7edea01d7cda00acb9f12f5746fd00dc4271f689` | master is identical, ahead 0 / behind 0 | DELETE CANDIDATE |
+| `Jokersochi/opensre` | `Tracer-Cloud/opensre` | `08b33468850bfda5f955f6343544521efd11bc35` | main is an upstream ancestor, ahead 0 / behind 2066 | DELETE CANDIDATE |
+
+## Exclusions
+
+All other audited forks remain excluded from deletion because they have at least one of:
+
+- unique commits, branches or unmerged PRs;
+- product code or custom assets;
+- open bot PRs that require a recorded disposition;
+- an unverified dependency, deployment, release or history condition.
+
+## Execution sequence
+
+1. Verify this manifest once more at action time.
+2. Delete one repository at a time in GitHub Settings.
+3. Confirm the repository page returns not found.
+4. Record the exact time and result in Issue #58.
+5. Stop immediately if GitHub reports a dependency, transfer, or recovery concern.
+
+No repository was archived or deleted while this document was created.

--- a/docs/portfolio/DELETE_MANIFEST.md
+++ b/docs/portfolio/DELETE_MANIFEST.md
@@ -9,7 +9,7 @@ Each repository below passes the strict safety gate:
 - no local commits not present in upstream;
 - no side branches;
 - no open PR or issue;
-- no release, deployment, package or GitHub Pages site;
+- no release, tag, deployment, package or GitHub Pages site;
 - no indexed reference from another Jokersochi repository;
 - exact upstream and recovery commit recorded.
 
@@ -36,4 +36,4 @@ All other audited forks remain excluded from deletion because they have at least
 4. Record the exact time and result in Issue #58.
 5. Stop immediately if GitHub reports a dependency, transfer, or recovery concern.
 
-No repository was archived or deleted while this document was created.
+All three fork repositories were also verified to have zero tag refs.\n\nNo repository was archived or deleted while this document was created.


### PR DESCRIPTION
## What changed

Adds a single source of truth for GitHub portfolio cleanup: verified portfolio metrics, canonical product decisions, P0 execution queue and deletion safeguards.

## Why

The profile repository is the intended home for portfolio documentation and orchestration. This separates governance from product code and prevents untracked archive/delete decisions.

## Validation

- Content is documentation-only.
- No production code, dependency, workflow, secret or deployment configuration changed.
- The PR intentionally remains a draft until the active fork and PR audits are attached.