### PR TITLE
fix: make profile CSS lint configuration self-contained

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "stylelint-no-physical-properties"
-  ],
-  "rules": {
-    "plugin/no-physical-properties": [true, { "disableFix": false }]
-  }
-} 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,6 @@
 module.exports = {
-  extends: ['stylelint-config-standard'],
   rules: {
-    // Запрещаем физические CSS-свойства (margin-left, padding-right и т.д.)
+    // Keep the project-specific logical-property policy without external plugins.
     'declaration-property-value-disallowed-list': {
       '/^(margin|padding|border)-(left|right|top|bottom)/': [/.*/],
       '/^(left|right|top|bottom)$/': [/.*/],
@@ -10,4 +9,4 @@ module.exports = {
       '/^border-(top|bottom|left|right)-(left|right)-radius$/': [/.*/]
     }
   }
-}; 
+};


### PR DESCRIPTION
Replaces the broken configuration chain without changing CSS or application behavior:

- removes the missing `stylelint-config-standard` extension;
- deletes the obsolete `stylelint-no-physical-properties` config;
- keeps the project-specific built-in Stylelint rule.

This is the minimal current fix identified while reviewing legacy PR #6. It intentionally does not merge that stale PR or update unrelated dependencies.