### PR TITLE
ci: fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,21 +2,39 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7.0.0
         with:
-          node-version: 18
-      - run: npm install
-      - run: npm run build
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist 
+          publish_dir: ./dist
+          publish_branch: gh-pages


### PR DESCRIPTION
## What changed

- grant the Pages workflow `contents: write` so `github-actions[bot]` can create and push `gh-pages`
- update `actions/checkout` to `v7.0.1`, `actions/setup-node` to `v7.0.0`, and `peaceiris/actions-gh-pages` to `v4.1.0`
- align the deploy workflow with Node.js 22 and replace `npm install` with reproducible `npm ci`
- add `workflow_dispatch`, concurrency control, and a 10-minute job timeout

## Root cause

[Deploy to GitHub Pages #25](https://github.com/Jokersochi/Jokersochi/actions/runs/31201501105) built successfully but failed while pushing `gh-pages`: the workflow token had `Contents: read`, resulting in `403 Permission denied to github-actions[bot]`.

## Impact

The next push to `main` can publish the generated `dist` directory to the `gh-pages` branch. No application code is changed.

## Validation

- YAML parsed successfully with `js-yaml`
- `npm ci` completed
- `npm run build` completed with Vite 5.4.20