### PR TITLE
fix: make Vite assets portable on GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 export default {
   root: './',
+  base: './',
   server: {
     port: 5173
   }
-}; 
+};


### PR DESCRIPTION
## What changed

- Set Vite `base` to `./` so production assets use relative URLs.

## Why

This repository is published as a GitHub Pages project site under `/Jokersochi/`. Root-absolute `/assets/...` URLs would load from the domain root and return 404s.

## Validation

- `npm ci`
- `npm run build`
- Verified `dist/index.html` references `./assets/...`.