### PR TITLE
feat(visage): rebuild studio into a useful premium workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,15 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ru">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Visage Studio — виртуальный визаж</title>
-    <meta
-      name="description"
-      content="Загрузите свою фотографию и примеряйте разные варианты макияжа из готовых шаблонов в приложении Visage Studio."
-    />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/demo-face.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#0d0c10" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="description" content="Visage Studio — локальный рабочий стол для примерки макияжа на собственном фото." />
+    <meta property="og:title" content="Visage Studio — макияж, который выглядит как ваш" />
+    <meta property="og:description" content="Соберите образ на своём фото, сравните до и после и скачайте результат. Фото остаётся в браузере." />
+    <meta property="og:type" content="website" />
+    <title>Visage Studio — рабочий стол визажиста</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -2,501 +2,481 @@ import './style.css';
 import { templates } from './templates.js';
 import demoFaceUrl from './assets/demo-face.svg?url';
 
+const STORAGE_KEY = 'visage-studio-session-v3';
 const primaryTemplate = templates[0];
-const state = {
-  templateId: primaryTemplate.id,
-  ...createTemplateDefaults(primaryTemplate),
-  hintDismissed: false
+
+const GROUPS = [
+  { id: 'base', label: 'Кожа', sublabel: 'Румянец, сияние и контур', layers: ['blush', 'contour', 'highlight'], defaultValue: 0.76 },
+  { id: 'eyes', label: 'Глаза', sublabel: 'Тени и линия ресниц', layers: ['shadow', 'liner'], defaultValue: 0.78 },
+  { id: 'lips', label: 'Губы', sublabel: 'Цвет и мягкий блеск', layers: ['lips'], defaultValue: 0.74 }
+];
+
+const SOFTNESS = {
+  blush: 0.7,
+  contour: 0.42,
+  highlight: 0.5,
+  shadow: 0.72,
+  liner: 0.66,
+  lips: 0.78
 };
 
+const ICONS = {
+  sparkle: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2 1.35 6.65L20 10l-6.65 1.35L12 18l-1.35-6.65L4 10l6.65-1.35L12 2Z"/><path d="m19 16 .6 2.4L22 19l-2.4.6L19 22l-.6-2.4L16 19l2.4-.6L19 16Z"/></svg>',
+  upload: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 16V4m0 0L7.5 8.5M12 4l4.5 4.5M5 14v4.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V14"/></svg>',
+  download: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v11m0 0-4-4m4 4 4-4M5 20h14"/></svg>',
+  sun: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.93 4.93l1.42 1.42M17.65 17.65l1.42 1.42M2 12h2M20 12h2M4.93 19.07l1.42-1.42M17.65 6.35l1.42-1.42"/></svg>',
+  eye: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.5 12s3.4-5 9.5-5 9.5 5 9.5 5-3.4 5-9.5 5-9.5-5-9.5-5Z"/><circle cx="12" cy="12" r="2.2"/></svg>',
+  rotate: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 9a8 8 0 1 1 1.9 8.2M4 4v5h5"/></svg>',
+  reset: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12a8 8 0 1 0 2.34-5.66L4 8.68M4 4v4.68h4.68"/></svg>',
+  moon: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 15.7A8.5 8.5 0 0 1 8.3 3.5 8.5 8.5 0 1 0 20.5 15.7Z"/></svg>',
+  sunSmall: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3.25"/><path d="M12 2.5v2M12 19.5v2M4.88 4.88l1.42 1.42M17.7 17.7l1.42 1.42M2.5 12h2M19.5 12h2M4.88 19.12l1.42-1.42M17.7 6.3l1.42-1.42"/></svg>',
+  arrow: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h13m-5-5 5 5-5 5"/></svg>',
+  check: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 4.2 4.2L19 6.5"/></svg>',
+  shield: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 19 6v5.2c0 4.4-2.9 7.9-7 9.8-4.1-1.9-7-5.4-7-9.8V6l7-3Z"/><path d="m9 12 2 2 4-4"/></svg>'
+};
+
+const icon = (name) => ICONS[name] ?? '';
 const app = document.querySelector('#app');
 
 if (!app) {
   throw new Error('Не удалось найти корневой элемент приложения.');
 }
 
+const savedSession = readSession();
+const savedTemplate = templates.find((item) => item.id === savedSession?.templateId) ?? primaryTemplate;
+
+const state = {
+  templateId: savedTemplate.id,
+  ...createTemplateDefaults(savedTemplate),
+  groupMix: createGroupMix(savedSession?.groupMix),
+  visibleGroups: createVisibleGroups(savedSession?.visibleGroups),
+  activeTab: 'look',
+  activeFilter: 'all',
+  showBefore: false,
+  hintDismissed: false,
+  zoom: 1,
+  photoMode: 'demo',
+  photoFileName: '',
+  photoObjectUrl: ''
+};
+
 app.innerHTML = `
   <div class="app-shell">
-    <header class="app-shell__header">
-      <div class="branding">
-        <h1>Visage Studio</h1>
-        <p>Загрузите свою фотографию и примеряйте готовые образы макияжа. Тон, тени и губы можно настроить под свои черты лица.</p>
-      </div>
-      <div class="header-actions">
-        <label class="label-button primary-btn">
-          <input type="file" accept="image/*" data-action="upload" />
-          <span>Загрузить фото</span>
-        </label>
-        <button type="button" class="secondary-btn" data-action="demo">Демо-фото</button>
-        <button type="button" class="neutral-btn" data-action="reset">Сбросить настройки</button>
+    <header class="topbar">
+      <a class="brand" href="#top" aria-label="Visage Studio — начало">
+        <span class="brand__mark">${icon('sparkle')}</span>
+        <span class="brand__wordmark"><strong>VISAGE</strong><em>Studio</em></span>
+      </a>
+      <nav class="topnav" aria-label="Основная навигация">
+        <a class="topnav__link is-active" href="#workspace">Рабочее место</a>
+        <a class="topnav__link" href="#guidance">Как получить точнее</a>
+      </nav>
+      <div class="topbar__actions">
+        <span class="privacy-chip">${icon('shield')} Фото остаётся в браузере</span>
+        <button class="icon-button" type="button" data-action="theme" aria-label="Переключить тему">${icon('moon')}</button>
       </div>
     </header>
-    <main class="app-shell__body">
-      <aside class="panel templates-panel" aria-label="Выбор образа">
-        <div>
-          <h2>Готовые образы</h2>
-          <p>Выберите шаблон макияжа и настройте его интенсивность и оттенки.</p>
+
+    <section class="hero" id="top">
+      <div class="hero__copy">
+        <p class="eyebrow"><span class="eyebrow__dot"></span>Визажистский рабочий стол</p>
+        <h1>Макияж, который<br /><span>выглядит как ваш.</span></h1>
+        <p class="hero__lede">Соберите образ на своём фото, сравните «до и после» и скачайте аккуратный результат. Без регистрации и без отправки фотографии на сервер.</p>
+      </div>
+      <div class="hero__actions">
+        <label class="button button--primary button--large">
+          <input type="file" accept="image/*" data-action="upload" />
+          ${icon('upload')}<span>Добавить фото</span>
+        </label>
+        <button class="button button--ghost button--large" type="button" data-action="demo">Открыть демо</button>
+      </div>
+    </section>
+
+    <main class="app-shell__body" id="workspace">
+      <aside class="panel library-panel" aria-label="Библиотека образов">
+        <div class="panel__heading">
+          <div>
+            <p class="panel__kicker">01 / LOOKS</p>
+            <h2>Выберите направление</h2>
+          </div>
+          <span class="panel__count">${templates.length} образа</span>
+        </div>
+        <p class="panel__intro">Готовые палитры для разных задач — от свежего дневного света до съёмки.</p>
+        <div class="filter-tabs" role="tablist" aria-label="Фильтр образов">
+          <button type="button" class="filter-tab is-active" data-filter="all" role="tab" aria-selected="true">Все</button>
+          <button type="button" class="filter-tab" data-filter="day" role="tab" aria-selected="false">День</button>
+          <button type="button" class="filter-tab" data-filter="evening" role="tab" aria-selected="false">Вечер</button>
         </div>
         <div class="template-list" data-role="template-list"></div>
-      </aside>
-      <div class="workspace">
-        <section class="stage" aria-label="Предпросмотр макияжа">
-          <div class="stage__inner" data-role="stage-inner">
-            <img class="stage__photo" src="${demoFaceUrl}" alt="Предпросмотр лица" data-role="photo" draggable="false" />
-            <canvas class="stage__overlay" data-role="overlay" aria-hidden="true"></canvas>
-            <div class="stage__hint" data-role="drag-hint">Перетащите макияж, чтобы подстроить позицию</div>
-          </div>
-          <div class="status-bar" data-role="status" aria-live="polite">Загрузите своё фото или используйте демонстрационное.</div>
-        </section>
-        <div class="workspace__side">
-          <section class="panel controls-panel" aria-label="Настройки образа">
-            <h2>Настройки образа</h2>
-            <div class="control">
-              <label for="control-intensity">Интенсивность макияжа</label>
-              <output data-role="value-intensity">${formatIntensity(state.intensity)}</output>
-              <input id="control-intensity" class="control-range" type="range" min="0" max="1" step="0.01" value="${state.intensity}" />
-            </div>
-            <div class="control">
-              <label for="control-scale">Масштаб шаблона</label>
-              <output data-role="value-scale">${formatScale(state.scale)}</output>
-              <input id="control-scale" class="control-range" type="range" min="0.8" max="1.3" step="0.01" value="${state.scale}" />
-            </div>
-            <div class="control">
-              <label for="control-rotation">Поворот</label>
-              <output data-role="value-rotation">${formatRotation(state.rotation)}</output>
-              <input id="control-rotation" class="control-range" type="range" min="-15" max="15" step="0.5" value="${state.rotation}" />
-            </div>
-            <div class="control">
-              <label for="control-warmth">Баланс оттенка</label>
-              <output data-role="value-warmth">${formatWarmth(state.warmth)}</output>
-              <input id="control-warmth" class="control-range" type="range" min="-0.5" max="0.5" step="0.01" value="${state.warmth}" />
-            </div>
-            <div class="control">
-              <label for="control-exposure">Экспозиция</label>
-              <output data-role="value-exposure">${formatExposure(state.exposure)}</output>
-              <input id="control-exposure" class="control-range" type="range" min="-0.3" max="0.3" step="0.01" value="${state.exposure}" />
-            </div>
-          </section>
-          <section class="variant-panel" data-role="variant-panel" aria-label="Вариации оттенков">
-            <h2>Вариации оттенков</h2>
-            <div class="variant-list" data-role="variant-list"></div>
-            <p class="variant-item__description" data-role="variant-description"></p>
-          </section>
-          <section class="template-meta" aria-live="polite">
-            <h2 data-role="template-name"></h2>
-            <p class="template-meta__text" data-role="template-description"></p>
-            <ul class="template-meta__tags" data-role="template-tags"></ul>
-          </section>
+        <div class="library-note">
+          <span class="library-note__icon">${icon('sparkle')}</span>
+          <div><strong>Подсказка</strong><p>Начните с умеренной интенсивности, а затем добавляйте цвет.</p></div>
         </div>
-      </div>
+      </aside>
+
+      <section class="workspace" aria-label="Рабочая область">
+        <div class="workspace__header">
+          <div>
+            <p class="panel__kicker">02 / PREVIEW</p>
+            <h2 data-role="template-name">${savedTemplate.name}</h2>
+          </div>
+          <div class="workspace__actions">
+            <span class="live-badge"><span></span>Локальная обработка</span>
+            <button class="button button--soft" type="button" data-action="download">${icon('download')} Скачать результат</button>
+          </div>
+        </div>
+
+        <section class="stage" aria-label="Предпросмотр образа">
+          <div class="stage__frame" data-role="stage-frame" data-mode="demo">
+            <div class="stage__grid" aria-hidden="true"></div>
+            <img class="stage__photo" src="${demoFaceUrl}" alt="Демонстрационный портрет" data-role="photo" draggable="false" />
+            <canvas class="stage__overlay" data-role="overlay" aria-hidden="true"></canvas>
+            <div class="stage__caption"><span class="stage__caption-dot"></span><span data-role="photo-label">Демонстрационный портрет</span></div>
+            <div class="stage__hint" data-role="drag-hint">Потяните изображение, чтобы выровнять образ</div>
+            <div class="stage__empty" data-role="stage-empty" hidden>
+              <span class="stage__empty-icon">${icon('upload')}</span>
+              <strong>Добавьте портрет</strong>
+              <span>Лучше всего работает фронтальный снимок при мягком свете.</span>
+              <label class="button button--light"><input type="file" accept="image/*" data-action="upload" />${icon('upload')} Выбрать фото</label>
+            </div>
+          </div>
+          <div class="stage__toolbar">
+            <div class="stage__toolbar-group">
+              <button class="tool-button" type="button" data-action="before" aria-pressed="false"><span class="tool-button__icon">${icon('eye')}</span><span data-role="before-label">До / После</span></button>
+              <button class="tool-button" type="button" data-action="center">${icon('reset')} Центрировать</button>
+            </div>
+            <div class="stage__toolbar-group stage__zoom">
+              <button class="zoom-button" type="button" data-action="zoom-out" aria-label="Уменьшить">−</button>
+              <span data-role="zoom-label">100%</span>
+              <button class="zoom-button" type="button" data-action="zoom-in" aria-label="Увеличить">+</button>
+            </div>
+          </div>
+          <div class="status-line" data-role="status" data-status="neutral" aria-live="polite"><span class="status-line__dot"></span><span data-role="status-text">Добавьте фото или используйте демо‑портрет.</span></div>
+        </section>
+
+        <div class="insight-grid" id="guidance">
+          <article class="insight-card insight-card--readiness">
+            <div class="insight-card__icon">${icon('check')}</div>
+            <div><p class="insight-card__label">Готовность фото</p><strong data-role="readiness-title">Демо‑портрет готов</strong><span data-role="readiness-text">Можно сразу выбирать образ</span></div>
+          </article>
+          <article class="insight-card">
+            <div class="insight-card__icon insight-card__icon--warm">${icon('sparkle')}</div>
+            <div><p class="insight-card__label">Для точного результата</p><strong>Свет прямо на лицо</strong><span>Без сильных теней и фильтров камеры</span></div>
+          </article>
+        </div>
+      </section>
+
+      <aside class="panel inspector-panel" aria-label="Настройки образа">
+        <div class="inspector__top">
+          <div><p class="panel__kicker">03 / REFINE</p><h2>Настройте образ</h2></div>
+          <button class="icon-button icon-button--small" type="button" data-action="reset" aria-label="Сбросить настройки">${icon('reset')}</button>
+        </div>
+        <div class="inspector-tabs" role="tablist" aria-label="Разделы настроек">
+          <button class="inspector-tab is-active" type="button" data-tab="look" role="tab" aria-selected="true">Образ</button>
+          <button class="inspector-tab" type="button" data-tab="photo" role="tab" aria-selected="false">Фото</button>
+        </div>
+        <div class="inspector-panel__content" data-tab-panel="look">
+          <div class="control-section">
+            <div class="control-section__heading"><div><p class="panel__kicker">MIX</p><h3>Слои образа</h3></div><span class="control-section__hint">Включить / смягчить</span></div>
+            <div class="group-list" data-role="group-list"></div>
+          </div>
+          <div class="control-section control-section--compact">
+            <div class="control-section__heading"><div><p class="panel__kicker">TONE</p><h3>Вариант оттенка</h3></div></div>
+            <div class="variant-list" data-role="variant-list"></div>
+            <p class="variant-description" data-role="variant-description"></p>
+          </div>
+          <div class="control-section control-section--compact">
+            <div class="control-section__heading"><div><p class="panel__kicker">FINISH</p><h3>Общая интенсивность</h3></div><output data-role="value-intensity">82%</output></div>
+            <input class="range range--accent" data-control="intensity" type="range" min="0" max="1" step="0.01" value="0.82" aria-label="Общая интенсивность" />
+            <div class="range-labels"><span>Естественно</span><span>Выразительно</span></div>
+          </div>
+        </div>
+        <div class="inspector-panel__content" data-tab-panel="photo" hidden>
+          <div class="photo-guidance">
+            <div class="photo-guidance__hero"><span>${icon('sun')}</span><div><strong>Подготовьте хороший кадр</strong><p>Так макияж будет выглядеть ближе к реальному результату.</p></div></div>
+            <ul class="guidance-list"><li>${icon('check')}Лицо прямо в камеру</li><li>${icon('check')}Ровный мягкий свет</li><li>${icon('check')}Без очков и сильных фильтров</li><li>${icon('check')}Минимум 720 px по ширине</li></ul>
+            <div class="privacy-box">${icon('shield')}<span>Фото не загружается на сервер и исчезает после закрытия вкладки.</span></div>
+          </div>
+        </div>
+        <div class="inspector__footer"><span>${icon('sparkle')} Тонкая настройка без лишнего</span><span class="keyboard-hint">B — сравнение</span></div>
+      </aside>
     </main>
+    <div class="toast" data-role="toast" role="status" aria-live="polite"></div>
   </div>
 `;
 
 const templateList = app.querySelector('[data-role="template-list"]');
-const variantPanel = app.querySelector('[data-role="variant-panel"]');
+const groupList = app.querySelector('[data-role="group-list"]');
 const variantList = app.querySelector('[data-role="variant-list"]');
 const variantDescription = app.querySelector('[data-role="variant-description"]');
 const templateName = app.querySelector('[data-role="template-name"]');
-const templateDescription = app.querySelector('[data-role="template-description"]');
-const templateTags = app.querySelector('[data-role="template-tags"]');
-const statusBar = app.querySelector('[data-role="status"]');
-const stageInner = app.querySelector('[data-role="stage-inner"]');
+const statusText = app.querySelector('[data-role="status-text"]');
+const statusLine = app.querySelector('[data-role="status"]');
+const stageFrame = app.querySelector('[data-role="stage-frame"]');
 const stageHint = app.querySelector('[data-role="drag-hint"]');
+const stageEmpty = app.querySelector('[data-role="stage-empty"]');
+const photoLabel = app.querySelector('[data-role="photo-label"]');
 const photoElement = app.querySelector('[data-role="photo"]');
 const overlayCanvas = app.querySelector('[data-role="overlay"]');
-const uploadInput = app.querySelector('input[data-action="upload"]');
-const demoButton = app.querySelector('button[data-action="demo"]');
-const resetButton = app.querySelector('button[data-action="reset"]');
+const overlayContext = overlayCanvas?.getContext('2d', { alpha: true });
+const readinessTitle = app.querySelector('[data-role="readiness-title"]');
+const readinessText = app.querySelector('[data-role="readiness-text"]');
+const zoomLabel = app.querySelector('[data-role="zoom-label"]');
+const beforeLabel = app.querySelector('[data-role="before-label"]');
+const toast = app.querySelector('[data-role="toast"]');
 
-if (!templateList || !variantPanel || !variantList || !templateName || !templateDescription || !templateTags || !statusBar || !stageInner || !stageHint || !photoElement || !overlayCanvas || !uploadInput || !demoButton || !resetButton) {
-  throw new Error('Не удалось инициализировать интерфейс приложения.');
+if (!templateList || !groupList || !variantList || !variantDescription || !templateName || !statusText || !statusLine || !stageFrame || !stageHint || !stageEmpty || !photoElement || !overlayCanvas || !overlayContext) {
+  throw new Error('Не удалось инициализировать рабочую область Visage Studio.');
 }
 
-const overlayContext = overlayCanvas.getContext('2d', { alpha: true });
-
-if (!overlayContext) {
-  throw new Error('Браузер не поддерживает 2D-контекст для canvas.');
-}
-
-const controlElements = {
-  intensity: {
-    input: document.getElementById('control-intensity'),
-    output: app.querySelector('[data-role="value-intensity"]')
-  },
-  scale: {
-    input: document.getElementById('control-scale'),
-    output: app.querySelector('[data-role="value-scale"]')
-  },
-  rotation: {
-    input: document.getElementById('control-rotation'),
-    output: app.querySelector('[data-role="value-rotation"]')
-  },
-  warmth: {
-    input: document.getElementById('control-warmth'),
-    output: app.querySelector('[data-role="value-warmth"]')
-  },
-  exposure: {
-    input: document.getElementById('control-exposure'),
-    output: app.querySelector('[data-role="value-exposure"]')
-  }
-};
-
-Object.values(controlElements).forEach(({ input, output }) => {
-  if (!input || !output) {
-    throw new Error('Элемент управления не найден на странице.');
-  }
-});
+const intensityInput = app.querySelector('[data-control="intensity"]');
+const dragState = { isActive: false, pointerId: null, origin: { x: 0, y: 0 }, offset: { x: 0, y: 0 } };
+let toastTimer;
+let renderFrame = null;
 
 buildTemplateCards();
-selectTemplate(state.templateId, { reset: true, silent: true });
-setupVariantInteractions();
-updateTemplateMeta();
-updateControlsFromState();
+buildGroupControls();
+selectTemplate(state.templateId, { reset: false, silent: true });
+setupInteractions();
 initializeCanvas();
+updatePhotoUi();
+updateZoomUi();
 renderAll();
 
-uploadInput.addEventListener('change', handleUpload);
-demoButton.addEventListener('click', () => {
-  revokeObjectUrl();
-  photoElement.src = demoFaceUrl;
-  state.hintDismissed = false;
-  stageHint.classList.remove('is-hidden');
-  setStatus('Загружено демонстрационное фото.', 'success');
-});
+function setupInteractions() {
+  app.addEventListener('click', handleClick);
+  app.addEventListener('change', (event) => {
+    const input = event.target.closest('input[data-action="upload"]');
+    if (input) handleUpload(event);
+  });
+  intensityInput.addEventListener('input', (event) => {
+    state.intensity = clamp(Number.parseFloat(event.target.value), 0, 1);
+    app.querySelector('[data-role="value-intensity"]').textContent = formatPercent(state.intensity);
+    scheduleRender();
+  });
+  stageFrame.addEventListener('pointerdown', onPointerDown);
+  stageFrame.addEventListener('pointermove', onPointerMove);
+  stageFrame.addEventListener('pointerup', onPointerUp);
+  stageFrame.addEventListener('pointercancel', onPointerUp);
+  stageFrame.addEventListener('pointerleave', () => { if (dragState.isActive) onPointerUp(); });
+  photoElement.addEventListener('load', handlePhotoLoad);
+  photoElement.addEventListener('error', () => {
+    setStatus('Не удалось загрузить это изображение. Попробуйте другой файл.', 'warning');
+    updatePhotoUi();
+  });
+  document.addEventListener('keydown', (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+      event.preventDefault();
+      downloadResult();
+    }
+    if (event.key.toLowerCase() === 'b' && !isTypingTarget(event.target)) toggleBeforeAfter();
+    if (event.key === 'Escape' && state.showBefore) toggleBeforeAfter(false);
+  });
+}
 
-resetButton.addEventListener('click', () => {
-  const template = getCurrentTemplate();
-  if (!template) return;
-  applyTemplateDefaults(template);
-  updateControlsFromState();
-  state.hintDismissed = false;
-  stageHint.classList.remove('is-hidden');
-  renderAll();
-  setStatus('Настройки образа сброшены.', 'success');
-});
-
-stageInner.addEventListener('pointerdown', onPointerDown);
-stageInner.addEventListener('pointermove', onPointerMove);
-stageInner.addEventListener('pointerup', onPointerUp);
-stageInner.addEventListener('pointercancel', onPointerUp);
-stageInner.addEventListener('pointerleave', () => {
-  if (dragState.isActive) {
-    onPointerUp();
+function handleClick(event) {
+  const action = event.target.closest('[data-action]')?.dataset.action;
+  if (action) {
+    if (action === 'demo') loadDemoPhoto();
+    if (action === 'reset') resetLook();
+    if (action === 'before') toggleBeforeAfter();
+    if (action === 'center') centerStage();
+    if (action === 'zoom-in') setZoom(state.zoom + 0.1);
+    if (action === 'zoom-out') setZoom(state.zoom - 0.1);
+    if (action === 'download') downloadResult();
+    if (action === 'theme') toggleTheme();
   }
-});
 
-photoElement.addEventListener('load', handlePhotoLoad);
-photoElement.addEventListener('error', () => {
-  revokeObjectUrl();
-  setStatus('Не удалось загрузить изображение. Попробуйте другой файл.', 'warning');
-});
+  const filter = event.target.closest('[data-filter]');
+  if (filter) setFilter(filter.dataset.filter);
+
+  const tab = event.target.closest('[data-tab]');
+  if (tab) setActiveTab(tab.dataset.tab);
+}
 
 function buildTemplateCards() {
   templateList.innerHTML = '';
-
-  templates.forEach((template) => {
+  templates.forEach((template, index) => {
     const card = document.createElement('button');
     card.type = 'button';
     card.className = 'template-card';
     card.dataset.id = template.id;
+    card.dataset.filter = index === 0 ? 'day' : index === 1 ? 'evening' : 'day';
     card.setAttribute('aria-pressed', template.id === state.templateId ? 'true' : 'false');
-
-    const preview = document.createElement('span');
-    preview.className = 'template-card__preview';
-    preview.style.setProperty('--preview', template.preview);
-
-    const content = document.createElement('div');
-    const title = document.createElement('span');
-    title.className = 'template-card__title';
-    title.textContent = template.name;
-
-    const description = document.createElement('p');
-    description.className = 'template-card__description';
-    description.textContent = template.description;
-
-    content.append(title, description);
-    card.append(preview, content);
-
+    card.innerHTML = `<span class="template-card__preview" style="--preview:${template.preview}"><span class="template-card__index">0${index + 1}</span><span class="template-card__arrow">${icon('arrow')}</span></span><span class="template-card__body"><strong>${escapeHtml(template.name)}</strong><span>${escapeHtml(template.tags?.[0] ?? 'Персональный образ')}</span></span>`;
     card.addEventListener('click', () => {
-      if (state.templateId === template.id) {
-        return;
-      }
-
-      selectTemplate(template.id, { reset: true });
-      setStatus(`Применён образ «${template.name}».`, 'success');
+      if (state.templateId === template.id) return;
+      selectTemplate(template.id);
+      setStatus(`Образ «${template.name}» применён.`, 'success');
     });
-
     templateList.append(card);
   });
-}
-
-function setupVariantInteractions() {
-  variantList.addEventListener('click', (event) => {
-    const target = event.target;
-    const button = target instanceof HTMLElement ? target.closest('.variant-item') : null;
-    if (!button) return;
-
-    const { variant: variantId } = button.dataset;
-    if (!variantId || variantId === state.variantId) {
-      return;
-    }
-
-    state.variantId = variantId;
-    updateVariantActiveState();
-    renderAll();
-
-    const variant = getCurrentVariant();
-    if (variant) {
-      setStatus(`Выбрана вариация «${variant.name}».`, 'success');
-    }
-  });
-}
-
-function selectTemplate(templateId, { reset = false, silent = false } = {}) {
-  const template = templates.find((item) => item.id === templateId);
-  if (!template) {
-    console.warn(`Шаблон с идентификатором ${templateId} не найден.`);
-    return;
-  }
-
-  state.templateId = template.id;
-
-  if (reset) {
-    applyTemplateDefaults(template);
-    updateControlsFromState();
-  }
-
   updateTemplateCards();
-  updateVariantPanel();
-  updateTemplateMeta();
-  renderAll();
-
-  if (!silent) {
-    const variant = getCurrentVariant();
-    if (variant) {
-      setStatus(`Применён образ «${template.name}» – вариация «${variant.name}».`, 'success');
-    } else {
-      setStatus(`Применён образ «${template.name}».`, 'success');
-    }
-  }
 }
 
-function updateTemplateCards() {
-  const cards = templateList.querySelectorAll('.template-card');
-  cards.forEach((card) => {
-    const isActive = card.dataset.id === state.templateId;
-    card.classList.toggle('is-active', isActive);
-    card.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+function buildGroupControls() {
+  groupList.innerHTML = '';
+  GROUPS.forEach((group) => {
+    const row = document.createElement('div');
+    row.className = 'group-control';
+    row.dataset.group = group.id;
+    row.innerHTML = `<div class="group-control__top"><button type="button" class="group-toggle" data-group-toggle="${group.id}" aria-pressed="${state.visibleGroups[group.id] ? 'true' : 'false'}"><span class="group-toggle__dot"></span><span><strong>${group.label}</strong><small>${group.sublabel}</small></span></button><output data-group-output="${group.id}">${formatPercent(state.groupMix[group.id])}</output></div><input class="range" data-group-input="${group.id}" type="range" min="0" max="1" step="0.01" value="${state.groupMix[group.id]}" aria-label="Интенсивность: ${group.label}" />`;
+    const input = row.querySelector('[data-group-input]');
+    const toggle = row.querySelector('[data-group-toggle]');
+    input.addEventListener('input', (event) => {
+      state.groupMix[group.id] = clamp(Number.parseFloat(event.target.value), 0, 1);
+      row.querySelector('[data-group-output]').textContent = formatPercent(state.groupMix[group.id]);
+      scheduleRender();
+    });
+    toggle.addEventListener('click', () => {
+      state.visibleGroups[group.id] = !state.visibleGroups[group.id];
+      toggle.setAttribute('aria-pressed', String(state.visibleGroups[group.id]));
+      row.classList.toggle('is-muted', !state.visibleGroups[group.id]);
+      scheduleRender();
+    });
+    groupList.append(row);
   });
 }
 
 function updateVariantPanel() {
   const template = getCurrentTemplate();
   const variants = template?.variants ?? [];
-
-  if (!variants.length) {
-    variantPanel.hidden = true;
-    variantList.innerHTML = '';
-    variantDescription.textContent = '';
-    return;
-  }
-
-  variantPanel.hidden = false;
   variantList.innerHTML = '';
-
   variants.forEach((variant) => {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'variant-item';
     button.dataset.variant = variant.id;
     button.setAttribute('aria-pressed', variant.id === state.variantId ? 'true' : 'false');
-
-    const preview = document.createElement('span');
-    preview.className = 'variant-item__preview';
     const [a, b, c] = variant.preview ?? [];
-    preview.style.setProperty('--swatch-a', a ?? '#d1d5ff');
-    preview.style.setProperty('--swatch-b', b ?? a ?? '#fbcfe8');
-    preview.style.setProperty('--swatch-c', c ?? b ?? a ?? '#fde68a');
-
-    const title = document.createElement('span');
-    title.className = 'variant-item__title';
-    title.textContent = variant.name;
-
-    button.append(preview, title);
+    button.innerHTML = `<span class="variant-item__swatch" style="--swatch-a:${a ?? '#d1d5ff'};--swatch-b:${b ?? a ?? '#fbcfe8'};--swatch-c:${c ?? b ?? a ?? '#fde68a'}"></span><span class="variant-item__name">${escapeHtml(variant.name)}</span><span class="variant-item__check">${icon('check')}</span>`;
+    button.addEventListener('click', () => {
+      state.variantId = variant.id;
+      updateVariantActiveState();
+      scheduleRender();
+      setStatus(`Оттенок «${variant.name}» выбран.`, 'success');
+    });
     variantList.append(button);
   });
-
   updateVariantActiveState();
-  updateVariantDescription();
 }
 
 function updateVariantActiveState() {
-  const buttons = variantList.querySelectorAll('.variant-item');
-  buttons.forEach((button) => {
+  variantList.querySelectorAll('.variant-item').forEach((button) => {
     const isActive = button.dataset.variant === state.variantId;
     button.classList.toggle('is-active', isActive);
-    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    button.setAttribute('aria-pressed', String(isActive));
   });
-  updateVariantDescription();
-}
-
-function updateVariantDescription() {
   const variant = getCurrentVariant();
   variantDescription.textContent = variant?.description ?? '';
 }
 
-function updateTemplateMeta() {
-  const template = getCurrentTemplate();
-  if (!template) {
-    return;
-  }
+function selectTemplate(templateId, { reset = true, silent = false } = {}) {
+  const template = templates.find((item) => item.id === templateId);
+  if (!template) return;
+  const apply = () => {
+    state.templateId = template.id;
+    if (reset) applyTemplateDefaults(template);
+    updateTemplateCards();
+    updateVariantPanel();
+    templateName.textContent = template.name;
+    intensityInput.value = String(state.intensity);
+    app.querySelector('[data-role="value-intensity"]').textContent = formatPercent(state.intensity);
+    scheduleRender();
+  };
+  if (!silent && document.startViewTransition) document.startViewTransition(apply);
+  else apply();
+}
 
-  templateName.textContent = template.name;
-  templateDescription.textContent = template.description;
-  templateTags.innerHTML = '';
-
-  template.tags?.forEach((tag) => {
-    const item = document.createElement('li');
-    item.className = 'template-meta__tag';
-    item.textContent = tag;
-    templateTags.append(item);
+function updateTemplateCards() {
+  templateList.querySelectorAll('.template-card').forEach((card) => {
+    const isActive = card.dataset.id === state.templateId;
+    const visible = state.activeFilter === 'all' || card.dataset.filter === state.activeFilter;
+    card.hidden = !visible;
+    card.classList.toggle('is-active', isActive);
+    card.setAttribute('aria-pressed', String(isActive));
   });
 }
 
-function updateControlsFromState() {
-  controlElements.intensity.input.value = String(state.intensity);
-  controlElements.intensity.output.textContent = formatIntensity(state.intensity);
-
-  controlElements.scale.input.value = String(state.scale);
-  controlElements.scale.output.textContent = formatScale(state.scale);
-
-  controlElements.rotation.input.value = String(state.rotation);
-  controlElements.rotation.output.textContent = formatRotation(state.rotation);
-
-  controlElements.warmth.input.value = String(state.warmth);
-  controlElements.warmth.output.textContent = formatWarmth(state.warmth);
-
-  controlElements.exposure.input.value = String(state.exposure);
-  controlElements.exposure.output.textContent = formatExposure(state.exposure);
+function setFilter(filter) {
+  state.activeFilter = filter;
+  app.querySelectorAll('[data-filter]').forEach((button) => {
+    const active = button.dataset.filter === filter;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-selected', String(active));
+  });
+  updateTemplateCards();
 }
 
-controlElements.intensity.input.addEventListener('input', (event) => {
-  const value = Number.parseFloat(event.target.value);
-  if (Number.isFinite(value)) {
-    state.intensity = clamp(value, 0, 1);
-    controlElements.intensity.output.textContent = formatIntensity(state.intensity);
-    renderAll();
-  }
-});
-
-controlElements.scale.input.addEventListener('input', (event) => {
-  const value = Number.parseFloat(event.target.value);
-  if (Number.isFinite(value)) {
-    state.scale = clamp(value, 0.6, 1.5);
-    controlElements.scale.output.textContent = formatScale(state.scale);
-    renderAll();
-  }
-});
-
-controlElements.rotation.input.addEventListener('input', (event) => {
-  const value = Number.parseFloat(event.target.value);
-  if (Number.isFinite(value)) {
-    state.rotation = clamp(value, -30, 30);
-    controlElements.rotation.output.textContent = formatRotation(state.rotation);
-    renderAll();
-  }
-});
-
-controlElements.warmth.input.addEventListener('input', (event) => {
-  const value = Number.parseFloat(event.target.value);
-  if (Number.isFinite(value)) {
-    state.warmth = clamp(value, -1, 1);
-    controlElements.warmth.output.textContent = formatWarmth(state.warmth);
-    updateImageFilter();
-  }
-});
-
-controlElements.exposure.input.addEventListener('input', (event) => {
-  const value = Number.parseFloat(event.target.value);
-  if (Number.isFinite(value)) {
-    state.exposure = clamp(value, -0.5, 0.5);
-    controlElements.exposure.output.textContent = formatExposure(state.exposure);
-    updateImageFilter();
-  }
-});
+function setActiveTab(tab) {
+  state.activeTab = tab;
+  app.querySelectorAll('[data-tab]').forEach((button) => {
+    const active = button.dataset.tab === tab;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-selected', String(active));
+  });
+  app.querySelectorAll('[data-tab-panel]').forEach((panel) => { panel.hidden = panel.dataset.tabPanel !== tab; });
+}
 
 function initializeCanvas() {
-  const resizeObserver = new ResizeObserver((entries) => {
-    for (const entry of entries) {
-      const { width, height } = entry.contentRect;
-      const ratio = window.devicePixelRatio || 1;
-      overlayCanvas.width = Math.max(1, Math.round(width * ratio));
-      overlayCanvas.height = Math.max(1, Math.round(height * ratio));
-      overlayCanvas.style.width = `${width}px`;
-      overlayCanvas.style.height = `${height}px`;
-      overlayContext.setTransform(ratio, 0, 0, ratio, 0, 0);
-      renderAll();
-    }
+  const resizeObserver = new ResizeObserver(() => {
+    const rect = stageFrame.getBoundingClientRect();
+    const ratio = window.devicePixelRatio || 1;
+    overlayCanvas.width = Math.max(1, Math.round(rect.width * ratio));
+    overlayCanvas.height = Math.max(1, Math.round(rect.height * ratio));
+    overlayCanvas.style.width = `${rect.width}px`;
+    overlayCanvas.style.height = `${rect.height}px`;
+    scheduleRender();
   });
+  resizeObserver.observe(stageFrame);
+}
 
-  resizeObserver.observe(stageInner);
+function scheduleRender() {
+  if (renderFrame) cancelAnimationFrame(renderFrame);
+  renderFrame = requestAnimationFrame(() => {
+    renderFrame = null;
+    renderAll();
+  });
+  persistSession();
 }
 
 function renderAll() {
   drawOverlay();
   updateImageFilter();
+  updateBeforeAfterState();
+  updateZoomUi();
 }
 
 function drawOverlay() {
-  const template = getCurrentTemplate();
-  if (!template) {
-    return;
-  }
-
+  const width = overlayCanvas.clientWidth || stageFrame.clientWidth;
+  const height = overlayCanvas.clientHeight || stageFrame.clientHeight;
   const ratio = window.devicePixelRatio || 1;
   overlayContext.setTransform(1, 0, 0, 1, 0, 0);
   overlayContext.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+  if (state.showBefore || !width || !height) return;
   overlayContext.setTransform(ratio, 0, 0, ratio, 0, 0);
-
-  const width = overlayCanvas.width / ratio;
-  const height = overlayCanvas.height / ratio;
-
-  if (width === 0 || height === 0) {
-    return;
-  }
-
+  const template = getCurrentTemplate();
   const variant = getCurrentVariant();
+  if (!template) return;
 
   overlayContext.save();
   overlayContext.translate(width / 2 + state.offset.x * width, height / 2 + state.offset.y * height);
   overlayContext.rotate((state.rotation * Math.PI) / 180);
-  overlayContext.scale(state.scale, state.scale);
+  overlayContext.scale(state.scale * state.zoom, state.scale * state.zoom);
   overlayContext.translate(-width / 2, -height / 2);
-
   template.overlays.forEach((layer) => {
+    const groupId = groupForLayer(layer.group);
+    if (groupId && !state.visibleGroups[groupId]) return;
     const color = resolveLayerColor(layer, variant);
-    const opacity = resolveLayerOpacity(layer, variant);
-
-    if (!color || opacity <= 0) {
-      return;
-    }
-
+    const opacity = resolveLayerOpacity(layer, variant, groupId);
+    if (!color || opacity <= 0) return;
     overlayContext.save();
     overlayContext.globalAlpha = opacity;
     overlayContext.globalCompositeOperation = layer.blend ?? 'source-over';
-
-    if (layer.blur) {
-      const blurRadius = (layer.blur * Math.max(width, height)).toFixed(2);
-      overlayContext.filter = `blur(${blurRadius}px)`;
-    } else {
-      overlayContext.filter = 'none';
-    }
-
+    overlayContext.filter = layer.blur ? `blur(${(layer.blur * Math.max(width, height)).toFixed(2)}px)` : 'none';
     drawLayer(overlayContext, layer, width, height, color);
     overlayContext.restore();
   });
-
   overlayContext.restore();
   overlayContext.setTransform(1, 0, 0, 1, 0, 0);
 }
@@ -507,199 +487,148 @@ function drawLayer(ctx, layer, width, height, color) {
   const rx = (layer.rx ?? 0) * width;
   const ry = (layer.ry ?? 0) * height;
   const rotation = ((layer.rotation ?? 0) * Math.PI) / 180;
-
   ctx.save();
   ctx.translate(x, y);
-  if (rotation) {
-    ctx.rotate(rotation);
-  }
-
+  if (rotation) ctx.rotate(rotation);
   if (layer.type === 'ellipse') {
     ctx.beginPath();
     ctx.ellipse(0, 0, rx, ry, 0, 0, Math.PI * 2);
-    if (layer.stroke) {
-      ctx.lineWidth = (layer.stroke ?? 0.005) * Math.max(width, height);
-      ctx.strokeStyle = color;
-      ctx.stroke();
-    } else {
-      ctx.fillStyle = color;
-      ctx.fill();
-    }
+    ctx.fillStyle = color;
+    ctx.fill();
   } else if (layer.type === 'rect') {
     const w = (layer.width ?? 0.1) * width;
     const h = (layer.height ?? 0.05) * height;
     ctx.fillStyle = color;
     ctx.fillRect(-w / 2, -h / 2, w, h);
   }
-
   ctx.restore();
 }
 
 function resolveLayerColor(layer, variant) {
-  if (variant?.roles && layer.group && variant.roles[layer.group]) {
-    return variant.roles[layer.group];
-  }
-  return layer.color ?? null;
+  return variant?.roles?.[layer.group] ?? layer.color ?? null;
 }
 
-function resolveLayerOpacity(layer, variant) {
-  const baseOpacity = layer.opacity ?? 1;
-  const groupMultiplier = variant?.intensity?.[layer.group] ?? 1;
-  return clamp(baseOpacity * state.intensity * groupMultiplier, 0, 1);
+function resolveLayerOpacity(layer, variant, groupId) {
+  const base = layer.opacity ?? 1;
+  const variantMix = variant?.intensity?.[layer.group] ?? 1;
+  const groupMix = groupId ? state.groupMix[groupId] : 1;
+  const softness = SOFTNESS[layer.group] ?? 0.72;
+  return clamp(base * state.intensity * variantMix * groupMix * softness, 0, 1);
 }
 
 function updateImageFilter() {
   const template = getCurrentTemplate();
-  if (!template) {
+  if (!template) return;
+  if (state.showBefore) {
+    photoElement.style.filter = 'none';
     return;
   }
-
   const filters = template.filters ?? {};
-  const brightness = clamp((filters.brightness ?? 1) * (1 + state.exposure), 0.2, 2).toFixed(2);
+  const brightness = clamp((filters.brightness ?? 1) * (1 + state.exposure), 0.25, 2).toFixed(2);
   const contrast = clamp(filters.contrast ?? 1, 0.5, 2).toFixed(2);
   const saturate = clamp(filters.saturate ?? 1, 0.5, 2).toFixed(2);
   const warmth = (filters.warmth ?? 0) + state.warmth;
-  const sepia = filters.sepia ?? 0;
-
-  const parts = [
-    `brightness(${brightness})`,
-    `contrast(${contrast})`,
-    `saturate(${saturate})`
-  ];
-
-  if (sepia > 0) {
-    parts.push(`sepia(${sepia})`);
-  }
-
-  if (Math.abs(warmth) > 0.001) {
-    parts.push(`hue-rotate(${(warmth * 45).toFixed(1)}deg)`);
-  }
-
+  const parts = [`brightness(${brightness})`, `contrast(${contrast})`, `saturate(${saturate})`];
+  if (Math.abs(warmth) > 0.001) parts.push(`hue-rotate(${(warmth * 24).toFixed(1)}deg)`);
   photoElement.style.filter = parts.join(' ');
 }
 
 function handleUpload(event) {
   const input = event.target;
   const file = input.files?.[0];
-
-  if (!file) {
-    return;
-  }
-
+  if (!file) return;
   if (!file.type.startsWith('image/')) {
-    setStatus('Можно загрузить только изображение.', 'warning');
+    setStatus('Выберите файл изображения: JPG, PNG или WebP.', 'warning');
     input.value = '';
     return;
   }
-
+  if (file.size > 12 * 1024 * 1024) {
+    setStatus('Файл больше 12 МБ. Сожмите изображение и попробуйте снова.', 'warning');
+    input.value = '';
+    return;
+  }
   revokeObjectUrl();
   const objectUrl = URL.createObjectURL(file);
+  state.photoObjectUrl = objectUrl;
+  state.photoFileName = file.name;
+  state.photoMode = 'uploaded';
+  state.showBefore = false;
   photoElement.src = objectUrl;
-  photoElement.dataset.objectUrl = objectUrl;
-  state.hintDismissed = false;
   stageHint.classList.remove('is-hidden');
-  setStatus(`Загружено фото: ${file.name}`, 'success');
+  setStatus(`Фото «${file.name}» открыто локально.`, 'success');
   input.value = '';
+}
+
+function loadDemoPhoto() {
+  revokeObjectUrl();
+  state.photoMode = 'demo';
+  state.photoFileName = '';
+  state.showBefore = false;
+  photoElement.src = demoFaceUrl;
+  setStatus('Демо‑портрет открыт. Выберите образ справа.', 'success');
 }
 
 function handlePhotoLoad() {
   const { naturalWidth, naturalHeight } = photoElement;
-  if (Number.isFinite(naturalWidth) && Number.isFinite(naturalHeight) && naturalWidth > 0 && naturalHeight > 0) {
-    stageInner.style.aspectRatio = `${naturalWidth} / ${naturalHeight}`;
+  stageFrame.style.aspectRatio = naturalWidth > 0 && naturalHeight > 0 ? `${naturalWidth} / ${naturalHeight}` : '4 / 5';
+  stageFrame.dataset.mode = state.photoMode;
+  updatePhotoUi();
+  scheduleRender();
+}
+
+function updatePhotoUi() {
+  const isDemo = state.photoMode === 'demo';
+  stageFrame.dataset.mode = state.photoMode;
+  stageEmpty.hidden = true;
+  photoLabel.textContent = isDemo ? 'Демонстрационный портрет' : state.photoFileName || 'Ваш портрет';
+  if (isDemo) {
+    readinessTitle.textContent = 'Демо‑портрет готов';
+    readinessText.textContent = 'Можно сразу выбирать образ';
   } else {
-    stageInner.style.aspectRatio = '3 / 4';
-  }
-
-  if (photoElement.dataset.objectUrl) {
-    revokeObjectUrl();
-  }
-
-  renderAll();
-}
-
-const dragState = {
-  isActive: false,
-  pointerId: null,
-  origin: { x: 0, y: 0 },
-  offset: { x: 0, y: 0 }
-};
-
-function onPointerDown(event) {
-  dragState.isActive = true;
-  dragState.pointerId = event.pointerId;
-  dragState.origin = { x: event.clientX, y: event.clientY };
-  dragState.offset = { ...state.offset };
-  stageInner.setPointerCapture(event.pointerId);
-  stageInner.classList.add('is-dragging');
-
-  if (!state.hintDismissed) {
-    state.hintDismissed = true;
-    stageHint.classList.add('is-hidden');
+    const ready = photoElement.naturalWidth >= 720 && photoElement.naturalHeight >= 720;
+    readinessTitle.textContent = ready ? 'Фото подходит' : 'Проверьте разрешение';
+    readinessText.textContent = ready ? `${photoElement.naturalWidth} × ${photoElement.naturalHeight} px` : 'Рекомендуется минимум 720 px';
   }
 }
 
-function onPointerMove(event) {
-  if (!dragState.isActive || event.pointerId !== dragState.pointerId) {
-    return;
-  }
-
-  const rect = stageInner.getBoundingClientRect();
-  if (rect.width === 0 || rect.height === 0) {
-    return;
-  }
-
-  const dx = (event.clientX - dragState.origin.x) / rect.width;
-  const dy = (event.clientY - dragState.origin.y) / rect.height;
-
-  state.offset = {
-    x: clamp(dragState.offset.x + dx, -0.5, 0.5),
-    y: clamp(dragState.offset.y + dy, -0.5, 0.5)
-  };
-
-  drawOverlay();
+function toggleBeforeAfter(force) {
+  state.showBefore = typeof force === 'boolean' ? force : !state.showBefore;
+  setStatus(state.showBefore ? 'Показано исходное фото. Нажмите B или кнопку, чтобы вернуть образ.' : 'Показан текущий образ.', 'neutral');
+  scheduleRender();
 }
 
-function onPointerUp() {
-  if (!dragState.isActive) {
-    return;
-  }
-
-  if (dragState.pointerId !== null) {
-    try {
-      stageInner.releasePointerCapture(dragState.pointerId);
-    } catch (error) {
-      // ignore capture release errors
-    }
-  }
-
-  dragState.isActive = false;
-  dragState.pointerId = null;
-  stageInner.classList.remove('is-dragging');
+function updateBeforeAfterState() {
+  stageFrame.classList.toggle('is-before', state.showBefore);
+  beforeLabel.textContent = state.showBefore ? 'Показать образ' : 'До / После';
+  app.querySelector('[data-action="before"]')?.setAttribute('aria-pressed', String(state.showBefore));
 }
 
-function setStatus(message, status) {
-  statusBar.textContent = message;
-  if (status) {
-    statusBar.dataset.status = status;
-  } else {
-    delete statusBar.dataset.status;
-  }
+function centerStage() {
+  state.offset = { x: 0, y: 0 };
+  setStatus('Образ выровнен по центру.', 'success');
+  scheduleRender();
 }
 
-function getCurrentTemplate() {
-  return templates.find((template) => template.id === state.templateId) ?? null;
+function setZoom(value) {
+  state.zoom = clamp(Number(value), 0.8, 1.25);
+  updateZoomUi();
+  scheduleRender();
 }
 
-function getCurrentVariant() {
+function updateZoomUi() {
+  zoomLabel.textContent = `${Math.round(state.zoom * 100)}%`;
+  stageFrame.style.setProperty('--stage-zoom', state.zoom);
+}
+
+function resetLook() {
   const template = getCurrentTemplate();
-  if (!template) {
-    return null;
-  }
-  const variants = template.variants ?? [];
-  if (!variants.length) {
-    return null;
-  }
-  return variants.find((variant) => variant.id === state.variantId) ?? variants[0] ?? null;
+  if (!template) return;
+  applyTemplateDefaults(template);
+  buildGroupControls();
+  intensityInput.value = String(state.intensity);
+  app.querySelector('[data-role="value-intensity"]').textContent = formatPercent(state.intensity);
+  setStatus('Настройки текущего образа сброшены.', 'success');
+  scheduleRender();
 }
 
 function applyTemplateDefaults(template) {
@@ -711,63 +640,115 @@ function applyTemplateDefaults(template) {
   state.exposure = defaults.exposure;
   state.offset = { ...defaults.offset };
   state.variantId = defaults.variantId;
+  state.groupMix = createGroupMix();
+  state.visibleGroups = createVisibleGroups();
+}
+
+function downloadResult() {
+  if (!photoElement.complete || !photoElement.naturalWidth) {
+    setStatus('Сначала добавьте корректное фото.', 'warning');
+    return;
+  }
+  if (state.showBefore) toggleBeforeAfter(false);
+  const exportCanvas = document.createElement('canvas');
+  exportCanvas.width = photoElement.naturalWidth;
+  exportCanvas.height = photoElement.naturalHeight;
+  const ctx = exportCanvas.getContext('2d');
+  if (!ctx) return;
+  try {
+    ctx.filter = photoElement.style.filter || 'none';
+    ctx.drawImage(photoElement, 0, 0, exportCanvas.width, exportCanvas.height);
+    ctx.filter = 'none';
+    ctx.drawImage(overlayCanvas, 0, 0, exportCanvas.width, exportCanvas.height);
+    exportCanvas.toBlob((blob) => {
+      if (!blob) return;
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `visage-${slugify(getCurrentTemplate()?.name ?? 'look')}.png`;
+      link.click();
+      setTimeout(() => URL.revokeObjectURL(link.href), 1000);
+      setStatus('Результат скачан в PNG.', 'success');
+    }, 'image/png');
+  } catch (error) {
+    setStatus('Браузер не разрешил экспорт этого фото.', 'warning');
+  }
+}
+
+function toggleTheme() {
+  const light = document.body.dataset.theme === 'light';
+  document.body.dataset.theme = light ? 'dark' : 'light';
+  app.querySelector('[data-action="theme"]').innerHTML = icon(light ? 'moon' : 'sunSmall');
+  localStorage.setItem('visage-theme', light ? 'dark' : 'light');
+}
+
+function onPointerDown(event) {
+  if (event.target.closest('button, label')) return;
+  dragState.isActive = true;
+  dragState.pointerId = event.pointerId;
+  dragState.origin = { x: event.clientX, y: event.clientY };
+  dragState.offset = { ...state.offset };
+  stageFrame.setPointerCapture(event.pointerId);
+  stageFrame.classList.add('is-dragging');
+  stageHint.classList.add('is-hidden');
+}
+
+function onPointerMove(event) {
+  if (!dragState.isActive || event.pointerId !== dragState.pointerId) return;
+  const rect = stageFrame.getBoundingClientRect();
+  const dx = (event.clientX - dragState.origin.x) / rect.width;
+  const dy = (event.clientY - dragState.origin.y) / rect.height;
+  state.offset = { x: clamp(dragState.offset.x + dx, -0.5, 0.5), y: clamp(dragState.offset.y + dy, -0.5, 0.5) };
+  drawOverlay();
+}
+
+function onPointerUp() {
+  if (!dragState.isActive) return;
+  try { if (dragState.pointerId !== null) stageFrame.releasePointerCapture(dragState.pointerId); } catch (error) { /* no-op */ }
+  dragState.isActive = false;
+  dragState.pointerId = null;
+  stageFrame.classList.remove('is-dragging');
+  persistSession();
+}
+
+function setStatus(message, status = 'neutral') {
+  statusText.textContent = message;
+  statusLine.dataset.status = status;
+  if (status !== 'neutral') showToast(message, status);
+}
+
+function showToast(message, tone) {
+  toast.textContent = message;
+  toast.dataset.tone = tone;
+  toast.classList.add('is-visible');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toast.classList.remove('is-visible'), 2800);
 }
 
 function revokeObjectUrl() {
-  const objectUrl = photoElement.dataset.objectUrl;
-  if (!objectUrl) {
-    return;
-  }
-
-  URL.revokeObjectURL(objectUrl);
-  delete photoElement.dataset.objectUrl;
+  if (state.photoObjectUrl) URL.revokeObjectURL(state.photoObjectUrl);
+  state.photoObjectUrl = '';
 }
 
+function getCurrentTemplate() { return templates.find((template) => template.id === state.templateId) ?? null; }
+function getCurrentVariant() {
+  const variants = getCurrentTemplate()?.variants ?? [];
+  return variants.find((variant) => variant.id === state.variantId) ?? variants[0] ?? null;
+}
+function groupForLayer(layer) { return GROUPS.find((group) => group.layers.includes(layer))?.id ?? null; }
 function createTemplateDefaults(template) {
   const defaults = template.defaults ?? {};
-  return {
-    intensity: defaults.intensity ?? 0.85,
-    scale: defaults.scale ?? 1,
-    rotation: defaults.rotation ?? 0,
-    warmth: defaults.warmth ?? 0,
-    exposure: defaults.exposure ?? 0,
-    offset: {
-      x: defaults.offsetX ?? 0,
-      y: defaults.offsetY ?? 0
-    },
-    variantId:
-      template.defaultVariant ??
-      defaults.variantId ??
-      (Array.isArray(template.variants) && template.variants.length ? template.variants[0].id : null)
-  };
+  return { intensity: defaults.intensity ?? 0.82, scale: defaults.scale ?? 1, rotation: defaults.rotation ?? 0, warmth: defaults.warmth ?? 0, exposure: defaults.exposure ?? 0, offset: { x: defaults.offsetX ?? 0, y: defaults.offsetY ?? 0 }, variantId: template.defaultVariant ?? template.variants?.[0]?.id ?? null };
 }
+function createGroupMix(saved) { return Object.fromEntries(GROUPS.map((group) => [group.id, clamp(Number(saved?.[group.id] ?? group.defaultValue), 0, 1)])); }
+function createVisibleGroups(saved) { return Object.fromEntries(GROUPS.map((group) => [group.id, saved?.[group.id] !== false])); }
+function readSession() { try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null'); } catch (error) { return null; } }
+function persistSession() {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify({ templateId: state.templateId, groupMix: state.groupMix, visibleGroups: state.visibleGroups, intensity: state.intensity, zoom: state.zoom })); } catch (error) { /* private browsing can block storage */ }
+}
+function formatPercent(value) { return `${Math.round(clamp(value, 0, 1) * 100)}%`; }
+function clamp(value, min, max) { return Math.min(Math.max(Number.isFinite(value) ? value : min, min), max); }
+function slugify(value) { return value.toLowerCase().replace(/[^a-zа-яё0-9]+/gi, '-').replace(/^-|-$/g, ''); }
+function isTypingTarget(target) { return target instanceof HTMLElement && ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName); }
+function escapeHtml(value) { return String(value).replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char])); }
 
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function formatIntensity(value) {
-  return `${Math.round(clamp(value, 0, 1) * 100)}%`;
-}
-
-function formatScale(value) {
-  return `${Math.round(clamp(value, 0.5, 1.8) * 100)}%`;
-}
-
-function formatRotation(value) {
-  const rounded = Math.round(value);
-  const sign = rounded > 0 ? '+' : '';
-  return `${sign}${rounded}°`;
-}
-
-function formatWarmth(value) {
-  const degrees = Math.round(value * 45);
-  const sign = degrees > 0 ? '+' : '';
-  return `${sign}${degrees}°`;
-}
-
-function formatExposure(value) {
-  const percent = Math.round(value * 100);
-  const sign = percent > 0 ? '+' : '';
-  return `${sign}${percent}%`;
-}
+document.body.dataset.theme = localStorage.getItem('visage-theme') || 'dark';

--- a/src/main.js
+++ b/src/main.js
@@ -734,7 +734,10 @@ function getCurrentVariant() {
   const variants = getCurrentTemplate()?.variants ?? [];
   return variants.find((variant) => variant.id === state.variantId) ?? variants[0] ?? null;
 }
-function groupForLayer(layer) { return GROUPS.find((group) => group.layers.includes(layer))?.id ?? null; }
+function groupForLayer(layer) {
+  const layerName = typeof layer === 'string' ? layer : layer?.group;
+  return GROUPS.find((group) => group.layers.includes(layerName))?.id ?? null;
+}
 function createTemplateDefaults(template) {
   const defaults = template.defaults ?? {};
   return { intensity: defaults.intensity ?? 0.82, scale: defaults.scale ?? 1, rotation: defaults.rotation ?? 0, warmth: defaults.warmth ?? 0, exposure: defaults.exposure ?? 0, offset: { x: defaults.offsetX ?? 0, y: defaults.offsetY ?? 0 }, variantId: template.defaultVariant ?? template.variants?.[0]?.id ?? null };

--- a/src/style.css
+++ b/src/style.css
@@ -1,517 +1,319 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap');
+
 :root {
+  color-scheme: dark;
+  --bg: #0d0c10;
+  --bg-elevated: #121116;
+  --surface: rgba(25, 23, 29, 0.84);
+  --surface-strong: #1a1820;
+  --surface-soft: #211e28;
+  --line: rgba(255, 255, 255, 0.1);
+  --line-strong: rgba(255, 255, 255, 0.18);
+  --text: #f7f2ef;
+  --muted: #a9a1a4;
+  --faint: #777074;
+  --accent: #e6b29f;
+  --accent-strong: #f1c5b1;
+  --accent-ink: #241718;
+  --green: #9bd8bf;
+  --yellow: #f6d48f;
+  --danger: #f4a1a1;
+  --radius-xl: 28px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --shadow: 0 28px 80px rgba(0, 0, 0, 0.28);
+  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+body[data-theme='light'] {
   color-scheme: light;
-  font-family: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --gradient-bg: radial-gradient(circle at top left, rgba(236, 235, 255, 0.6), rgba(214, 228, 255, 0)),
-    radial-gradient(circle at bottom right, rgba(253, 226, 238, 0.65), rgba(255, 255, 255, 0));
-  --surface-primary: rgba(255, 255, 255, 0.86);
-  --surface-secondary: rgba(249, 249, 255, 0.8);
-  --surface-accent: rgba(233, 239, 255, 0.92);
-  --border-soft: rgba(120, 132, 165, 0.16);
-  --border-strong: rgba(120, 132, 165, 0.3);
-  --text-primary: #1f2937;
-  --text-secondary: rgba(31, 41, 55, 0.72);
-  --text-muted: rgba(31, 41, 55, 0.5);
-  --accent: #7056d9;
-  --accent-soft: rgba(112, 86, 217, 0.12);
-  --accent-strong: rgba(112, 86, 217, 0.22);
-  --success: #2dd4bf;
-  --warning: #f97316;
-  --panel-radius: 24px;
-  --transition: 180ms ease;
+  --bg: #f2eeeb;
+  --bg-elevated: #f8f5f2;
+  --surface: rgba(255, 255, 255, 0.8);
+  --surface-strong: #fffdfa;
+  --surface-soft: #f1eae6;
+  --line: rgba(44, 30, 34, 0.11);
+  --line-strong: rgba(44, 30, 34, 0.18);
+  --text: #2b2023;
+  --muted: #76686d;
+  --faint: #9b8d90;
+  --accent: #b96e58;
+  --accent-strong: #c8826e;
+  --accent-ink: #fff8f4;
+  --shadow: 0 24px 60px rgba(81, 50, 42, 0.12);
 }
 
-* {
-  box-sizing: border-box;
-}
-
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 body {
+  min-width: 320px;
+  min-height: 100vh;
   margin: 0;
-  min-block-size: 100vh;
-  background: #f3f4ff;
-  background-image: var(--gradient-bg);
-  background-attachment: fixed;
-  color: var(--text-primary);
-  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg);
+  font-family: 'Manrope', Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+  transition: background-color 420ms var(--ease), color 420ms var(--ease);
 }
 
-body::before {
-  content: '';
+body::before, body::after {
   position: fixed;
-  inset: 0;
-  background: radial-gradient(circle at top right, rgba(126, 115, 255, 0.16), transparent 55%),
-    radial-gradient(circle at bottom left, rgba(255, 126, 189, 0.18), transparent 50%);
-  pointer-events: none;
   z-index: -1;
-}
-
-#app {
-  min-block-size: 100vh;
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  padding: clamp(16px, 3vw, 32px);
-}
-
-.app-shell {
-  inline-size: min(1200px, 100%);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(16px, 2.5vw, 28px);
-}
-
-.app-shell__header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: clamp(20px, 3vw, 32px);
-  background: var(--surface-primary);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 24px 48px rgba(120, 132, 165, 0.16);
-  backdrop-filter: blur(22px);
-}
-
-.branding h1 {
-  margin: 0;
-  font-size: clamp(1.8rem, 2.6vw, 2.4rem);
-  font-weight: 700;
-}
-
-.branding p {
-  margin: 8px 0 0;
-  max-inline-size: 45ch;
-  color: var(--text-secondary);
-}
-
-.header-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-}
-
-button,
-.label-button {
-  font: inherit;
-  border: none;
-  cursor: pointer;
+  display: block;
+  width: 38vw;
+  height: 38vw;
   border-radius: 999px;
-  padding: 10px 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  transition: transform var(--transition), box-shadow var(--transition), background-color var(--transition);
-}
-
-button:focus-visible,
-.label-button:focus-visible {
-  outline: 3px solid rgba(112, 86, 217, 0.35);
-  outline-offset: 2px;
-}
-
-.primary-btn {
-  background: linear-gradient(135deg, #7a5cff, #ff6cab);
-  color: #fff;
-  box-shadow: 0 10px 20px rgba(112, 86, 217, 0.26);
-}
-
-.primary-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 14px 26px rgba(112, 86, 217, 0.28);
-}
-
-.secondary-btn {
-  background: var(--accent-soft);
-  color: var(--accent);
-  border: 1px solid var(--accent-strong);
-}
-
-.secondary-btn:hover {
-  background: rgba(112, 86, 217, 0.18);
-}
-
-.neutral-btn {
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-soft);
-}
-
-.neutral-btn:hover {
-  background: rgba(255, 255, 255, 1);
-}
-
-input[type='file'] {
-  position: absolute;
-  inline-size: 1px;
-  block-size: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-}
-
-.app-shell__body {
-  display: grid;
-  grid-template-columns: minmax(260px, 320px) 1fr;
-  gap: clamp(16px, 2.8vw, 32px);
-}
-
-.panel {
-  background: var(--surface-primary);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--border-soft);
-  padding: clamp(18px, 2.4vw, 26px);
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  box-shadow: 0 18px 42px rgba(120, 132, 165, 0.16);
-  backdrop-filter: blur(20px);
-}
-
-.panel h2 {
-  margin: 0;
-  font-size: clamp(1.1rem, 1.6vw, 1.4rem);
-}
-
-.templates-panel p {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-.template-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.template-card {
-  position: relative;
-  border-radius: 18px;
-  border: 1px solid transparent;
-  padding: 16px;
-  background: var(--surface-secondary);
-  color: inherit;
-  text-align: left;
-  align-items: stretch;
-  display: grid;
-  grid-template-columns: 72px 1fr;
-  gap: 16px;
-  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
-}
-
-.template-card__preview {
-  border-radius: 16px;
-  background: var(--preview, linear-gradient(135deg, #d1d5ff, #ffe2f2));
-  position: relative;
-  overflow: hidden;
-}
-
-.template-card__preview::after {
   content: '';
-  position: absolute;
-  inset: 12px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.2);
-  mix-blend-mode: screen;
-}
-
-.template-card__title {
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-.template-card__description {
-  margin-top: 6px;
-  color: var(--text-secondary);
-  font-size: 0.92rem;
-}
-
-.template-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(112, 86, 217, 0.18);
-}
-
-.template-card.is-active {
-  border-color: rgba(112, 86, 217, 0.55);
-  box-shadow: 0 16px 32px rgba(112, 86, 217, 0.24);
-}
-
-.workspace {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
-  gap: clamp(16px, 2.5vw, 28px);
-  align-items: start;
-}
-
-.workspace__side {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(16px, 2vw, 24px);
-}
-
-.stage {
-  position: relative;
-  background: var(--surface-accent);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 18px 42px rgba(120, 132, 165, 0.2);
-  padding: clamp(12px, 1.8vw, 18px);
-}
-
-.stage__inner {
-  position: relative;
-  border-radius: clamp(20px, 3vw, 28px);
-  overflow: hidden;
-  background: #101223;
-  aspect-ratio: 3 / 4;
-  cursor: grab;
-  touch-action: none;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.stage__inner.is-dragging {
-  cursor: grabbing;
-}
-
-.stage__photo {
-  inline-size: 100%;
-  block-size: 100%;
-  object-fit: cover;
-  position: absolute;
-  inset: 0;
   pointer-events: none;
+  filter: blur(72px);
+  opacity: 0.18;
+}
+body::before { top: -14vw; left: -12vw; background: #9c526c; }
+body::after { right: -16vw; bottom: -18vw; background: #916a43; opacity: 0.13; }
+
+button, input { font: inherit; }
+button { color: inherit; }
+a { color: inherit; text-decoration: none; }
+svg { width: 1em; height: 1em; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+
+.app-shell { width: min(1500px, 100%); margin: 0 auto; padding: 0 34px 46px; }
+.topbar { display: flex; align-items: center; justify-content: space-between; min-height: 86px; gap: 24px; border-bottom: 1px solid var(--line); animation: rise 720ms var(--ease) both; }
+.brand { display: inline-flex; align-items: center; gap: 12px; }
+.brand__mark { display: grid; width: 32px; height: 32px; place-items: center; color: var(--accent-strong); border: 1px solid var(--line-strong); border-radius: 50%; background: linear-gradient(145deg, rgba(255,255,255,.1), rgba(255,255,255,.02)); font-size: 17px; box-shadow: 0 0 0 5px rgba(230, 178, 159, .05); }
+.brand__wordmark { display: inline-flex; align-items: baseline; gap: 6px; letter-spacing: .11em; font-size: 13px; }
+.brand__wordmark strong { font-weight: 800; }
+.brand__wordmark em { color: var(--accent); font-style: normal; font-weight: 500; letter-spacing: .02em; }
+.topnav { display: flex; align-items: center; gap: 30px; margin-left: auto; margin-right: auto; }
+.topnav__link { position: relative; padding: 32px 0 29px; color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: .02em; transition: color 220ms ease; }
+.topnav__link::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; background: var(--accent); transform: scaleX(0); transform-origin: left; transition: transform 260ms var(--ease); content: ''; }
+.topnav__link:hover, .topnav__link.is-active { color: var(--text); }
+.topnav__link.is-active::after { transform: scaleX(1); }
+.topbar__actions { display: flex; align-items: center; gap: 10px; }
+.privacy-chip { display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px; color: var(--muted); border: 1px solid var(--line); border-radius: 999px; font-size: 10px; white-space: nowrap; }
+.privacy-chip svg { color: var(--green); }
+.icon-button { display: inline-grid; width: 38px; height: 38px; place-items: center; padding: 0; color: var(--muted); border: 1px solid var(--line); border-radius: 50%; background: transparent; cursor: pointer; transition: color 220ms ease, border-color 220ms ease, transform 220ms var(--ease), background 220ms ease; }
+.icon-button:hover { color: var(--text); border-color: var(--line-strong); background: var(--surface-soft); transform: rotate(12deg); }
+.icon-button--small { width: 32px; height: 32px; border-radius: 10px; font-size: 14px; }
+
+.hero { display: flex; align-items: end; justify-content: space-between; gap: 32px; padding: 72px 0 58px; animation: rise 720ms 80ms var(--ease) both; }
+.eyebrow, .panel__kicker { margin: 0 0 12px; color: var(--accent); font-family: 'DM Mono', monospace; font-size: 10px; font-weight: 500; letter-spacing: .13em; text-transform: uppercase; }
+.eyebrow { display: flex; align-items: center; gap: 8px; }
+.eyebrow__dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 0 5px rgba(155, 216, 191, .08); animation: breathe 2.5s ease-in-out infinite; }
+.hero h1 { max-width: 760px; margin: 0; font-size: clamp(42px, 6.4vw, 86px); line-height: .98; letter-spacing: -.07em; font-weight: 700; }
+.hero h1 span { color: var(--accent); }
+.hero__lede { max-width: 600px; margin: 22px 0 0; color: var(--muted); font-size: 14px; line-height: 1.7; }
+.hero__actions { display: flex; align-items: center; gap: 10px; padding-bottom: 4px; }
+
+.button { display: inline-flex; align-items: center; justify-content: center; gap: 9px; min-height: 42px; padding: 0 16px; border: 1px solid transparent; border-radius: 12px; font-size: 12px; font-weight: 800; cursor: pointer; transition: transform 220ms var(--ease), background-color 220ms ease, border-color 220ms ease, color 220ms ease, box-shadow 220ms ease; }
+.button:hover { transform: translateY(-2px); }
+.button:active { transform: translateY(0); }
+.button svg { font-size: 16px; }
+.button--large { min-height: 48px; padding: 0 19px; }
+.button--primary { color: var(--accent-ink); background: var(--accent); box-shadow: 0 10px 26px rgba(230,178,159,.18); }
+.button--primary:hover { background: var(--accent-strong); box-shadow: 0 14px 32px rgba(230,178,159,.26); }
+.button--ghost { color: var(--text); border-color: var(--line-strong); background: rgba(255,255,255,.02); }
+.button--ghost:hover { border-color: var(--accent); background: rgba(230,178,159,.08); }
+.button--soft { min-height: 38px; color: var(--text); border-color: var(--line); background: var(--surface-soft); }
+.button--soft:hover { border-color: var(--line-strong); background: var(--surface-strong); }
+.button--light { color: #271a1b; background: #f8eee9; }
+.button--light:hover { background: #fffaf6; }
+.button input, .label-button input { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+
+.app-shell__body { display: grid; grid-template-columns: minmax(218px, 248px) minmax(0, 1fr) minmax(280px, 334px); gap: 16px; align-items: start; scroll-margin-top: 20px; }
+.panel { border: 1px solid var(--line); border-radius: var(--radius-lg); background: linear-gradient(145deg, rgba(255,255,255,.045), rgba(255,255,255,.012)), var(--surface); box-shadow: var(--shadow); backdrop-filter: blur(18px); }
+.library-panel, .inspector-panel { min-height: 718px; padding: 21px; animation: rise 720ms 180ms var(--ease) both; }
+.inspector-panel { animation-delay: 280ms; }
+.panel__heading, .inspector__top, .control-section__heading, .workspace__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.panel__heading h2, .inspector__top h2, .workspace__header h2 { margin: 0; font-size: 18px; letter-spacing: -.04em; }
+.panel__count, .control-section__hint { color: var(--faint); font-family: 'DM Mono', monospace; font-size: 9px; letter-spacing: .05em; white-space: nowrap; }
+.panel__intro { margin: 16px 0 18px; color: var(--muted); font-size: 11px; line-height: 1.65; }
+.filter-tabs { display: flex; gap: 4px; margin-bottom: 14px; padding: 4px; border: 1px solid var(--line); border-radius: 12px; background: rgba(0,0,0,.12); }
+.filter-tab { flex: 1; min-height: 29px; padding: 0 7px; color: var(--faint); border: 0; border-radius: 8px; background: transparent; font-size: 10px; font-weight: 700; cursor: pointer; transition: color 200ms ease, background 200ms ease, transform 200ms var(--ease); }
+.filter-tab:hover { color: var(--text); }
+.filter-tab.is-active { color: var(--text); background: var(--surface-soft); box-shadow: 0 5px 14px rgba(0,0,0,.16); }
+.template-list { display: grid; gap: 9px; }
+.template-card { display: grid; grid-template-columns: 54px 1fr; gap: 12px; align-items: center; width: 100%; padding: 8px; color: var(--text); border: 1px solid transparent; border-radius: 15px; background: transparent; text-align: left; cursor: pointer; transition: border-color 240ms ease, background 240ms ease, transform 240ms var(--ease); }
+.template-card:hover { border-color: var(--line); background: rgba(255,255,255,.035); transform: translateX(3px); }
+.template-card.is-active { border-color: rgba(230,178,159,.46); background: linear-gradient(100deg, rgba(230,178,159,.13), rgba(255,255,255,.02)); }
+.template-card__preview { position: relative; display: flex; align-items: end; justify-content: space-between; width: 54px; height: 64px; overflow: hidden; padding: 7px; border-radius: 11px; background: var(--preview); box-shadow: inset 0 -35px 30px rgba(22,16,24,.14); }
+.template-card__preview::before { position: absolute; top: 14px; left: 50%; width: 25px; height: 31px; border: 1px solid rgba(255,255,255,.35); border-radius: 45% 45% 46% 46%; transform: translateX(-50%); content: ''; }
+.template-card__preview::after { position: absolute; top: 25px; left: 50%; width: 31px; height: 11px; border-top: 1px solid rgba(255,255,255,.32); border-radius: 50%; transform: translateX(-50%); content: ''; }
+.template-card__index { position: relative; z-index: 1; color: rgba(255,255,255,.72); font-family: 'DM Mono', monospace; font-size: 9px; }
+.template-card__arrow { position: relative; z-index: 1; display: grid; width: 16px; height: 16px; place-items: center; color: rgba(255,255,255,.72); font-size: 12px; }
+.template-card__body { display: grid; gap: 5px; min-width: 0; }
+.template-card__body strong { overflow: hidden; font-size: 12px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+.template-card__body span { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.library-note { display: flex; gap: 10px; margin-top: 22px; padding: 13px; border: 1px solid var(--line); border-radius: 14px; background: rgba(230,178,159,.05); }
+.library-note__icon { display: grid; width: 23px; height: 23px; flex: 0 0 auto; place-items: center; color: var(--accent); border-radius: 8px; background: rgba(230,178,159,.1); font-size: 12px; }
+.library-note strong { display: block; margin-bottom: 3px; font-size: 10px; }
+.library-note p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.45; }
+
+.workspace { min-width: 0; }
+.workspace__header { align-items: center; min-height: 54px; margin: 0 3px 13px; }
+.workspace__header .panel__kicker { margin-bottom: 7px; }
+.workspace__actions { display: flex; align-items: center; gap: 10px; }
+.live-badge { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-family: 'DM Mono', monospace; font-size: 9px; white-space: nowrap; }
+.live-badge span { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 0 4px rgba(155,216,191,.08); animation: breathe 2.4s ease-in-out infinite; }
+.stage { padding: 12px; border: 1px solid var(--line); border-radius: var(--radius-xl); background: linear-gradient(145deg, rgba(255,255,255,.05), rgba(255,255,255,.012)), #0e0d11; box-shadow: var(--shadow); animation: rise 720ms 220ms var(--ease) both; }
+body[data-theme='light'] .stage { background: linear-gradient(145deg, rgba(255,255,255,.8), rgba(255,255,255,.25)), #e2d9d5; }
+.stage__frame { position: relative; width: 100%; min-height: 540px; overflow: hidden; aspect-ratio: 4 / 5; border: 1px solid rgba(255,255,255,.1); border-radius: 21px; background: radial-gradient(circle at 50% 34%, rgba(255,255,255,.09), transparent 36%), #19161d; cursor: grab; isolation: isolate; touch-action: none; transform: translateZ(0); }
+.stage__frame::before { position: absolute; z-index: 3; inset: 0; border: 1px solid rgba(255,255,255,.1); border-radius: inherit; box-shadow: inset 0 0 90px rgba(8,6,10,.35); pointer-events: none; content: ''; }
+.stage__frame::after { position: absolute; z-index: 2; right: 0; bottom: 0; left: 0; height: 34%; background: linear-gradient(transparent, rgba(10,8,12,.72)); pointer-events: none; content: ''; }
+.stage__frame.is-dragging { cursor: grabbing; }
+.stage__grid { position: absolute; z-index: 0; inset: 0; opacity: .12; background-image: linear-gradient(rgba(255,255,255,.16) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.16) 1px, transparent 1px); background-position: center; background-size: 25% 25%; mask-image: linear-gradient(transparent, #000 20%, #000 80%, transparent); pointer-events: none; }
+.stage__photo { position: absolute; z-index: 1; inset: 0; width: 100%; height: 100%; object-fit: cover; user-select: none; transition: filter 400ms var(--ease), transform 500ms var(--ease); }
+.stage__overlay { position: absolute; z-index: 2; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+.stage__caption { position: absolute; z-index: 5; right: 18px; bottom: 15px; display: flex; align-items: center; gap: 7px; color: rgba(255,255,255,.74); font-family: 'DM Mono', monospace; font-size: 9px; letter-spacing: .02em; }
+.stage__caption-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+.stage__hint { position: absolute; z-index: 5; top: 15px; left: 50%; padding: 8px 12px; color: rgba(255,255,255,.78); border: 1px solid rgba(255,255,255,.15); border-radius: 999px; background: rgba(10,8,12,.38); backdrop-filter: blur(10px); font-size: 10px; transform: translateX(-50%); transition: opacity 260ms ease, transform 260ms var(--ease); white-space: nowrap; }
+.stage__hint.is-hidden { opacity: 0; transform: translate(-50%, -6px); pointer-events: none; }
+.stage__empty { position: absolute; z-index: 6; inset: 50% auto auto 50%; display: grid; justify-items: center; gap: 9px; width: min(280px, 90%); padding: 28px 20px; color: #fff; border: 1px solid rgba(255,255,255,.16); border-radius: 20px; background: rgba(20,16,21,.78); backdrop-filter: blur(18px); text-align: center; transform: translate(-50%, -50%); }
+.stage__empty-icon { display: grid; width: 43px; height: 43px; place-items: center; border: 1px solid rgba(255,255,255,.18); border-radius: 14px; background: rgba(255,255,255,.08); color: var(--accent-strong); font-size: 20px; }
+.stage__empty strong { font-size: 16px; }
+.stage__empty > span:not(.stage__empty-icon) { color: rgba(255,255,255,.63); font-size: 11px; line-height: 1.5; }
+.stage__toolbar { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 11px 2px 1px; }
+.stage__toolbar-group { display: flex; align-items: center; gap: 5px; }
+.tool-button, .zoom-button { display: inline-flex; align-items: center; gap: 7px; min-height: 30px; padding: 0 9px; color: var(--muted); border: 1px solid transparent; border-radius: 9px; background: transparent; font-size: 10px; cursor: pointer; transition: color 200ms ease, border-color 200ms ease, background 200ms ease; }
+.tool-button:hover, .tool-button[aria-pressed='true'] { color: var(--text); border-color: var(--line); background: var(--surface-soft); }
+.tool-button svg { font-size: 13px; }
+.zoom-button { justify-content: center; width: 28px; padding: 0; border-color: var(--line); font-size: 15px; }
+.zoom-button:hover { color: var(--text); border-color: var(--line-strong); background: var(--surface-soft); }
+.stage__zoom > span { min-width: 35px; color: var(--muted); font-family: 'DM Mono', monospace; font-size: 9px; text-align: center; }
+.status-line { display: flex; align-items: center; gap: 8px; min-height: 30px; padding: 8px 4px 0; color: var(--muted); font-size: 10px; transition: color 220ms ease; }
+.status-line__dot { width: 6px; height: 6px; flex: 0 0 auto; border-radius: 50%; background: var(--faint); }
+.status-line[data-status='success'] .status-line__dot { background: var(--green); box-shadow: 0 0 0 4px rgba(155,216,191,.08); }
+.status-line[data-status='warning'] .status-line__dot { background: var(--yellow); }
+
+.insight-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-top: 12px; animation: rise 720ms 300ms var(--ease) both; }
+.insight-card { display: flex; align-items: center; gap: 11px; min-height: 72px; padding: 13px 14px; border: 1px solid var(--line); border-radius: 15px; background: var(--surface); }
+.insight-card__icon { display: grid; width: 28px; height: 28px; flex: 0 0 auto; place-items: center; color: var(--green); border-radius: 10px; background: rgba(155,216,191,.09); font-size: 14px; }
+.insight-card__icon--warm { color: var(--accent); background: rgba(230,178,159,.1); }
+.insight-card__label { margin: 0 0 4px; color: var(--faint); font-family: 'DM Mono', monospace; font-size: 8px; letter-spacing: .07em; text-transform: uppercase; }
+.insight-card strong { display: block; font-size: 11px; }
+.insight-card span:not(.insight-card__icon) { display: block; margin-top: 3px; color: var(--muted); font-size: 9px; }
+
+.inspector__top { align-items: center; }
+.inspector__top .panel__kicker { margin-bottom: 7px; }
+.inspector-tabs { display: flex; gap: 18px; margin: 26px 0 22px; border-bottom: 1px solid var(--line); }
+.inspector-tab { position: relative; padding: 0 0 12px; color: var(--faint); border: 0; background: transparent; font-size: 11px; font-weight: 800; cursor: pointer; }
+.inspector-tab::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; background: var(--accent); transform: scaleX(0); transform-origin: left; transition: transform 260ms var(--ease); content: ''; }
+.inspector-tab.is-active { color: var(--text); }
+.inspector-tab.is-active::after { transform: scaleX(1); }
+.inspector-panel__content[hidden] { display: none; }
+.control-section { padding-bottom: 22px; border-bottom: 1px solid var(--line); }
+.control-section + .control-section { padding-top: 22px; }
+.control-section--compact { padding-bottom: 18px; }
+.control-section__heading { align-items: center; margin-bottom: 14px; }
+.control-section__heading .panel__kicker { margin-bottom: 6px; }
+.control-section h3 { margin: 0; font-size: 12px; letter-spacing: -.02em; }
+.control-section__heading > output { color: var(--accent); font-family: 'DM Mono', monospace; font-size: 10px; }
+.group-list { display: grid; gap: 14px; }
+.group-control { transition: opacity 220ms ease; }
+.group-control.is-muted { opacity: .42; }
+.group-control__top { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; }
+.group-control__top output { color: var(--muted); font-family: 'DM Mono', monospace; font-size: 10px; }
+.group-toggle { display: flex; align-items: center; gap: 8px; padding: 0; color: var(--text); border: 0; background: transparent; text-align: left; cursor: pointer; }
+.group-toggle__dot { width: 8px; height: 8px; border: 2px solid var(--accent); border-radius: 50%; box-shadow: 0 0 0 3px rgba(230,178,159,.08); transition: background 200ms ease, transform 200ms var(--ease); }
+.group-toggle[aria-pressed='false'] .group-toggle__dot { background: transparent; border-color: var(--faint); box-shadow: none; transform: scale(.85); }
+.group-toggle[aria-pressed='true'] .group-toggle__dot { background: var(--accent); }
+.group-toggle strong, .group-toggle small { display: block; }
+.group-toggle strong { font-size: 11px; }
+.group-toggle small { margin-top: 2px; color: var(--muted); font-size: 9px; }
+.range { width: 100%; height: 4px; margin: 0; appearance: none; border-radius: 999px; outline: none; background: linear-gradient(90deg, var(--accent) var(--value, 72%), rgba(255,255,255,.12) var(--value, 72%)); cursor: pointer; }
+.range::-webkit-slider-thumb { width: 15px; height: 15px; appearance: none; border: 3px solid var(--surface-strong); border-radius: 50%; background: var(--accent-strong); box-shadow: 0 0 0 1px var(--accent); transition: transform 180ms var(--ease), box-shadow 180ms ease; }
+.range::-moz-range-thumb { width: 11px; height: 11px; border: 3px solid var(--surface-strong); border-radius: 50%; background: var(--accent-strong); box-shadow: 0 0 0 1px var(--accent); }
+.range:hover::-webkit-slider-thumb { transform: scale(1.22); box-shadow: 0 0 0 5px rgba(230,178,159,.12); }
+.range--accent { height: 5px; }
+.range-labels { display: flex; justify-content: space-between; margin-top: 8px; color: var(--faint); font-size: 8px; }
+.variant-list { display: grid; gap: 7px; }
+.variant-item { display: grid; grid-template-columns: 23px 1fr 15px; gap: 9px; align-items: center; width: 100%; min-height: 38px; padding: 0 9px; color: var(--muted); border: 1px solid transparent; border-radius: 10px; background: transparent; text-align: left; cursor: pointer; transition: color 200ms ease, border-color 200ms ease, background 200ms ease, transform 200ms var(--ease); }
+.variant-item:hover { color: var(--text); background: rgba(255,255,255,.035); transform: translateX(2px); }
+.variant-item.is-active { color: var(--text); border-color: rgba(230,178,159,.35); background: rgba(230,178,159,.08); }
+.variant-item__swatch { width: 22px; height: 22px; border-radius: 50%; background: linear-gradient(135deg, var(--swatch-a), var(--swatch-b) 52%, var(--swatch-c)); box-shadow: inset 0 0 0 1px rgba(255,255,255,.22); }
+.variant-item__name { font-size: 10px; font-weight: 700; }
+.variant-item__check { color: var(--accent); font-size: 12px; opacity: 0; transform: scale(.7); transition: opacity 200ms ease, transform 200ms var(--ease); }
+.variant-item.is-active .variant-item__check { opacity: 1; transform: scale(1); }
+.variant-description { min-height: 28px; margin: 10px 0 0; color: var(--muted); font-size: 9px; line-height: 1.55; }
+.photo-guidance__hero { display: flex; gap: 10px; padding: 13px; border: 1px solid var(--line); border-radius: 14px; background: rgba(230,178,159,.07); }
+.photo-guidance__hero > span { display: grid; width: 27px; height: 27px; flex: 0 0 auto; place-items: center; color: var(--accent); border-radius: 9px; background: rgba(230,178,159,.1); }
+.photo-guidance__hero strong { display: block; font-size: 11px; }
+.photo-guidance__hero p { margin: 4px 0 0; color: var(--muted); font-size: 9px; line-height: 1.5; }
+.guidance-list { display: grid; gap: 12px; margin: 21px 0; padding: 0; list-style: none; }
+.guidance-list li { display: flex; align-items: center; gap: 9px; color: var(--muted); font-size: 10px; }
+.guidance-list svg { width: 14px; color: var(--green); }
+.privacy-box { display: flex; gap: 8px; padding: 11px; color: var(--muted); border: 1px dashed var(--line-strong); border-radius: 12px; font-size: 9px; line-height: 1.5; }
+.privacy-box svg { width: 15px; flex: 0 0 auto; color: var(--green); }
+.inspector__footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 21px; color: var(--faint); font-family: 'DM Mono', monospace; font-size: 8px; }
+.inspector__footer svg { color: var(--accent); }
+.keyboard-hint { color: var(--faint); }
+
+.toast { position: fixed; z-index: 20; right: 24px; bottom: 24px; max-width: min(340px, calc(100vw - 48px)); padding: 12px 15px; color: var(--text); border: 1px solid var(--line-strong); border-radius: 12px; background: var(--surface-strong); box-shadow: var(--shadow); font-size: 11px; opacity: 0; pointer-events: none; transform: translateY(12px); transition: opacity 260ms ease, transform 260ms var(--ease); }
+.toast.is-visible { opacity: 1; transform: translateY(0); }
+.toast[data-tone='success'] { border-color: rgba(155,216,191,.36); }
+.toast[data-tone='warning'] { border-color: rgba(246,212,143,.36); }
+
+@keyframes rise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes breathe { 0%, 100% { opacity: .58; transform: scale(.9); } 50% { opacity: 1; transform: scale(1.12); } }
+
+@media (max-width: 1220px) {
+  .app-shell { padding-right: 22px; padding-left: 22px; }
+  .app-shell__body { grid-template-columns: minmax(200px, 230px) minmax(0, 1fr) minmax(250px, 300px); }
+  .stage__frame { min-height: 500px; }
+  .privacy-chip { display: none; }
 }
 
-.stage__overlay {
-  position: absolute;
-  inset: 0;
-  inline-size: 100%;
-  block-size: 100%;
-  pointer-events: none;
+@media (max-width: 980px) {
+  .topnav { display: none; }
+  .hero { display: block; padding: 54px 0 38px; }
+  .hero__actions { margin-top: 26px; }
+  .app-shell__body { grid-template-columns: 220px minmax(0, 1fr); }
+  .inspector-panel { grid-column: 1 / -1; min-height: auto; }
+  .inspector-panel__content { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 18px; }
+  .inspector-panel__content .control-section + .control-section { padding-top: 0; }
+  .inspector-panel__content .control-section { padding-bottom: 0; border-bottom: 0; }
+  .inspector-panel__content[hidden] { display: none; }
+  .stage__frame { min-height: 520px; }
 }
 
-.stage__hint {
-  position: absolute;
-  inset-inline: 16px;
-  inset-block-end: 16px;
-  padding: 10px 14px;
-  border-radius: 16px;
-  background: rgba(16, 18, 35, 0.65);
-  color: rgba(255, 255, 255, 0.86);
-  font-size: 0.9rem;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  transition: opacity var(--transition), transform var(--transition);
-}
-
-.stage__hint.is-hidden {
-  opacity: 0;
-  transform: translateY(8px);
-  pointer-events: none;
-}
-
-.controls-panel {
-  gap: 14px;
-}
-
-.control {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px;
-  align-items: center;
-}
-
-.control label {
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-.control output {
-  font-variant-numeric: tabular-nums;
-  color: var(--text-muted);
-}
-
-.control-range {
-  grid-column: 1 / -1;
-  appearance: none;
-  inline-size: 100%;
-  height: 6px;
-  border-radius: 999px;
-  background: rgba(112, 86, 217, 0.14);
-  overflow: hidden;
-}
-
-.control-range::-webkit-slider-thumb {
-  appearance: none;
-  inline-size: 18px;
-  block-size: 18px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #7a5cff, #ff6cab);
-  box-shadow: 0 6px 16px rgba(122, 92, 255, 0.3);
-}
-
-.control-range::-moz-range-thumb {
-  inline-size: 18px;
-  block-size: 18px;
-  border: none;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #7a5cff, #ff6cab);
-  box-shadow: 0 6px 16px rgba(122, 92, 255, 0.3);
-}
-
-.control-range::-moz-range-track {
-  height: 6px;
-  border-radius: 999px;
-  background: rgba(112, 86, 217, 0.14);
-}
-
-.status-bar {
-  margin-top: 6px;
-  font-size: 0.92rem;
-  color: var(--text-secondary);
-  min-height: 1.4em;
-}
-
-.status-bar[data-status='success'] {
-  color: var(--success);
-}
-
-.status-bar[data-status='warning'] {
-  color: var(--warning);
-}
-
-.variant-panel {
-  background: var(--surface-secondary);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--border-soft);
-  padding: clamp(16px, 2vw, 22px);
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.variant-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 12px;
-}
-
-.variant-item {
-  border-radius: 16px;
-  border: 1px solid transparent;
-  background: rgba(255, 255, 255, 0.72);
-  padding: 12px;
-  display: grid;
-  gap: 10px;
-  text-align: left;
-  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
-}
-
-.variant-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 26px rgba(112, 86, 217, 0.18);
-}
-
-.variant-item.is-active {
-  border-color: rgba(112, 86, 217, 0.55);
-  box-shadow: 0 12px 26px rgba(112, 86, 217, 0.24);
-}
-
-.variant-item__preview {
-  inline-size: 100%;
-  block-size: 36px;
-  border-radius: 14px;
-  background: linear-gradient(135deg, var(--swatch-a), var(--swatch-b), var(--swatch-c));
-  border: 1px solid rgba(255, 255, 255, 0.6);
-}
-
-.variant-item__title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--text-primary);
-}
-
-.variant-item__description {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-}
-
-.template-meta {
-  background: var(--surface-secondary);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--border-soft);
-  padding: clamp(16px, 2vw, 22px);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.template-meta__text {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-.template-meta__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.template-meta__tag {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(112, 86, 217, 0.12);
-  color: var(--accent);
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-@media (max-width: 1100px) {
-  .workspace {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 900px) {
-  .app-shell__body {
-    grid-template-columns: 1fr;
-  }
-
-  .app-shell__header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .header-actions {
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 720px) {
-  .stage__hint {
-    font-size: 0.8rem;
-  }
-
-  .variant-list {
-    grid-template-columns: 1fr;
-  }
+@media (max-width: 700px) {
+  .app-shell { padding: 0 14px 30px; }
+  .topbar { min-height: 70px; }
+  .topbar__actions { gap: 5px; }
+  .hero { padding: 38px 0 30px; }
+  .hero h1 { font-size: clamp(40px, 13vw, 62px); }
+  .hero__lede { font-size: 12px; }
+  .hero__actions { display: grid; grid-template-columns: 1fr 1fr; }
+  .button--large { width: 100%; padding: 0 10px; font-size: 11px; }
+  .app-shell__body { display: flex; flex-direction: column; gap: 12px; }
+  .workspace { display: contents; }
+  .workspace__header { order: 0; margin-top: 4px; }
+  .workspace__header .workspace__actions .live-badge { display: none; }
+  .library-panel { order: 1; width: 100%; min-height: auto; padding: 16px; }
+  .library-panel .panel__intro, .library-note { display: none; }
+  .template-list { display: flex; overflow-x: auto; gap: 8px; padding-bottom: 2px; scrollbar-width: none; }
+  .template-list::-webkit-scrollbar { display: none; }
+  .template-card { flex: 0 0 164px; grid-template-columns: 42px 1fr; padding: 6px; }
+  .template-card__preview { width: 42px; height: 52px; }
+  .template-card__preview::before { top: 11px; width: 20px; height: 26px; }
+  .template-card__preview::after { top: 20px; width: 25px; }
+  .template-card__body strong { font-size: 10px; }
+  .template-card__body span { font-size: 8px; }
+  .stage { order: 2; padding: 8px; }
+  .stage__frame { min-height: 0; border-radius: 16px; }
+  .stage__hint { max-width: calc(100% - 26px); overflow: hidden; font-size: 8px; text-overflow: ellipsis; }
+  .stage__toolbar { padding-top: 8px; }
+  .tool-button { padding: 0 5px; font-size: 9px; }
+  .tool-button:nth-child(2) { display: none; }
+  .insight-grid { order: 3; grid-template-columns: 1fr; }
+  .inspector-panel { order: 4; width: 100%; min-height: auto; padding: 16px; }
+  .inspector-panel__content { display: block; }
+  .inspector-panel__content .control-section { padding-bottom: 20px; border-bottom: 1px solid var(--line); }
+  .inspector-panel__content .control-section + .control-section { padding-top: 20px; }
+  .inspector__footer { margin-top: 16px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    transition-duration: 0.01ms !important;
-    animation-duration: 0.01ms !important;
-  }
+  *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; transition-duration: .01ms !important; }
 }


### PR DESCRIPTION
## Что изменено

Полностью переработан пользовательский сценарий Visage Studio:

- новый premium editorial интерфейс вместо мультяшной подачи;
- понятный поток: добавить фото → выбрать look → смягчить слои → сравнить до/после → скачать PNG;
- локальная обработка фото с явным privacy-состоянием;
- библиотека образов с фильтрами «Все / День / Вечер»;
- отдельные слои «Кожа / Глаза / Губы» с включением и интенсивностью;
- палитры оттенков, общая интенсивность, zoom и центрирование;
- сравнение «До / После» и клавиша B;
- экспорт текущего результата в PNG;
- сохранение настроек в localStorage;
- responsive layout для телефона и планшета;
- purposeful motion, view transitions и поддержка prefers-reduced-motion;
- обновлены metadata и описание приложения.

## Проверка

- JavaScript syntax check прошёл локально.
- CI должен проверить `npm ci`, unit tests и production build.
- После merge проверю Pages deployment и публичный интерфейс.