### PR TITLE
fix(visage): hide empty upload state over demo photo

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -170,6 +170,7 @@ body[data-theme='light'] .stage { background: linear-gradient(145deg, rgba(255,2
 .stage__hint { position: absolute; z-index: 5; top: 15px; left: 50%; padding: 8px 12px; color: rgba(255,255,255,.78); border: 1px solid rgba(255,255,255,.15); border-radius: 999px; background: rgba(10,8,12,.38); backdrop-filter: blur(10px); font-size: 10px; transform: translateX(-50%); transition: opacity 260ms ease, transform 260ms var(--ease); white-space: nowrap; }
 .stage__hint.is-hidden { opacity: 0; transform: translate(-50%, -6px); pointer-events: none; }
 .stage__empty { position: absolute; z-index: 6; inset: 50% auto auto 50%; display: grid; justify-items: center; gap: 9px; width: min(280px, 90%); padding: 28px 20px; color: #fff; border: 1px solid rgba(255,255,255,.16); border-radius: 20px; background: rgba(20,16,21,.78); backdrop-filter: blur(18px); text-align: center; transform: translate(-50%, -50%); }
+.stage__empty[hidden] { display: none; }
 .stage__empty-icon { display: grid; width: 43px; height: 43px; place-items: center; border: 1px solid rgba(255,255,255,.18); border-radius: 14px; background: rgba(255,255,255,.08); color: var(--accent-strong); font-size: 20px; }
 .stage__empty strong { font-size: 16px; }
 .stage__empty > span:not(.stage__empty-icon) { color: rgba(255,255,255,.63); font-size: 11px; line-height: 1.5; }


### PR DESCRIPTION
QA по опубликованной версии обнаружил, что атрибут hidden переопределялся display:grid у пустого состояния и перекрывал демо‑портрет. Добавлен явный стиль .stage__empty[hidden] { display: none; }.

Проверка: CI и Pages deployment.