### PR TITLE
PolyShark: replace momentum with persistent-elite consensus v3

### DIFF
--- a/.github/workflows/loto-refresh.yml
+++ b/.github/workflows/loto-refresh.yml
@@ -126,8 +126,14 @@ jobs:
         run: |
           python - <<'PY'
           from pathlib import Path
-          text = Path('polyshark-ai/runtime/paper_trader.py').read_text()
-          forbidden = ['create_order(', 'post_order(', 'cancel_all(', 'POLYMARKET_PRIVATE_KEY']
+          text = '\n'.join(
+              Path(path).read_text()
+              for path in (
+                  'polyshark-ai/runtime/paper_trader.py',
+                  'polyshark-ai/runtime/leader_consensus.py',
+              )
+          )
+          forbidden = ['create_order(', 'post_order(', 'cancel_all(', 'POLYMARKET_PRIVATE_KEY', '/order', '/orders']
           hits = [x for x in forbidden if x in text]
           if hits:
               raise SystemExit(f'Unsafe trading primitives found: {hits}')
@@ -142,8 +148,11 @@ jobs:
           PAPER_STARTING_EQUITY: "1000"
           PAPER_TARGET_EQUITY: "2000"
           PAPER_BANKRUPT_EQUITY: "0"
-          PAPER_MAX_POSITION_PCT: "0.05"
-          PAPER_MAX_OPEN_POSITIONS: "8"
+          PAPER_MAX_POSITION_PCT: "0.02"
+          PAPER_MAX_TOTAL_EXPOSURE_PCT: "0.08"
+          PAPER_MAX_OPEN_POSITIONS: "5"
+          PAPER_MAX_NEW_POSITIONS_PER_TICK: "1"
+          PAPER_MAX_DAILY_REALIZED_LOSS: "20"
         run: python polyshark-ai/runtime/paper_trader.py --state polyshark-ai/runtime/paper_state.json
 
       - name: Persist paper session state

--- a/.github/workflows/polyshark-paper-trading-v2.yml
+++ b/.github/workflows/polyshark-paper-trading-v2.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - "polyshark-ai/runtime/paper_trader.py"
+      - "polyshark-ai/runtime/leader_consensus.py"
       - "polyshark-ai/tests/test_paper_trader_runtime.py"
       - ".github/workflows/polyshark-paper-trading-v2.yml"
 
@@ -36,8 +37,14 @@ jobs:
         run: |
           python - <<'PY'
           from pathlib import Path
-          text = Path('polyshark-ai/runtime/paper_trader.py').read_text()
-          forbidden = ['create_order(', 'post_order(', 'cancel_all(', 'POLYMARKET_PRIVATE_KEY']
+          text = '\n'.join(
+              Path(path).read_text()
+              for path in (
+                  'polyshark-ai/runtime/paper_trader.py',
+                  'polyshark-ai/runtime/leader_consensus.py',
+              )
+          )
+          forbidden = ['create_order(', 'post_order(', 'cancel_all(', 'POLYMARKET_PRIVATE_KEY', '/order', '/orders']
           hits = [x for x in forbidden if x in text]
           if hits:
               raise SystemExit(f'Unsafe trading primitives found: {hits}')
@@ -52,8 +59,11 @@ jobs:
           PAPER_STARTING_EQUITY: "1000"
           PAPER_TARGET_EQUITY: "2000"
           PAPER_BANKRUPT_EQUITY: "0"
-          PAPER_MAX_POSITION_PCT: "0.05"
-          PAPER_MAX_OPEN_POSITIONS: "8"
+          PAPER_MAX_POSITION_PCT: "0.02"
+          PAPER_MAX_TOTAL_EXPOSURE_PCT: "0.08"
+          PAPER_MAX_OPEN_POSITIONS: "5"
+          PAPER_MAX_NEW_POSITIONS_PER_TICK: "1"
+          PAPER_MAX_DAILY_REALIZED_LOSS: "20"
         run: python polyshark-ai/runtime/paper_trader.py --state polyshark-ai/runtime/paper_state.json
 
       - name: Persist paper session state

--- a/polyshark-ai/README.md
+++ b/polyshark-ai/README.md
@@ -30,11 +30,16 @@ docker-compose up app         # API + агент
 ```
 
 ### 4. Paper trading (обязательно сначала!)
+```bash
+python runtime/paper_trader.py --state runtime/paper_state.json
 ```
-DRY_RUN=true в .env
-Мониторь логи: docker-compose logs -f agent
-Жди 100+ сигналов перед включением реальных ордеров
-```
+
+Автономный runtime работает только с публичными API и жёстко сохраняет
+`paper_only: true` / `real_orders_enabled: false`. Стратегия v3 не копирует
+одного лидера: она требует устойчивого рейтинга в нескольких периодах,
+минимум два независимых текущих голоса, свежий net-buy и цену не хуже чем на
+3 цента выше средней цены лидеров. Методика и выборка описаны в
+[`research/top-trader-analysis-2026-08-29.md`](research/top-trader-analysis-2026-08-29.md).
 
 ## Ключевые метрики перехода в прод
 
@@ -55,6 +60,8 @@ DRY_RUN=true в .env
 | `modules/validation.py` | Walk-Forward + Purging/Embargo |
 | `services/polymarket_client.py` | CLOB API (EIP-712) |
 | `services/ws_handler.py` | WebSocket стриминг |
+| `runtime/leader_consensus.py` | Публичный рейтинг, позиции, flow и consensus v3 |
+| `runtime/paper_trader.py` | Только виртуальное исполнение и риск-контроль |
 | `agents/orchestrator.py` | Главный агент |
 | `database/schema.sql` | Supabase DDL |
 
@@ -76,4 +83,4 @@ polyshark-ai/
 
 ⚠️ **НИКОГДА** не запускай с реальными деньгами без минимум 2 недель paper trading  
 ⚠️ **НИКОГДА** не храни приватный ключ в git (добавь `.env` в `.gitignore`)  
-⚠️ Максимальная позиция: 5% банкролла (настраивается в `MAX_POSITION_PCT`)
+⚠️ Максимальная paper-позиция: 2% equity; весь открытый book — не более 8%

--- a/polyshark-ai/research/top-trader-analysis-2026-08-29.md
+++ b/polyshark-ai/research/top-trader-analysis-2026-08-29.md
@@ -1,0 +1,58 @@
+# PolyShark: public Polymarket trader analysis
+
+Snapshot date: 2026-08-29 UTC. This is a reproducible behavioral inference from public data, not access to private models, bookmaker feeds, or trader intent.
+
+## Data and method
+
+- Pulled the official `OVERALL` PnL leaderboard for `DAY`, `WEEK`, `MONTH`, and `ALL`, top 50 per window.
+- Kept recurring addresses, then inspected up to 200 recent closed positions, 500 recent fills, and 500 current positions per address.
+- Measured recurrence across windows, PnL/volume as a rough efficiency screen, number of markets, entry-price distribution, concentration, buy/sell behavior, current exposure, and recent flow.
+- Sources: [leaderboard](https://docs.polymarket.com/api-reference/core/get-trader-leaderboard-rankings), [trades](https://docs.polymarket.com/api-reference/core/get-trades-for-a-user-or-markets), [current positions](https://docs.polymarket.com/api-reference/core/get-current-positions-for-a-user), and [closed positions](https://docs.polymarket.com/api-reference/core/get-closed-positions-for-a-user).
+
+The closed-position API sample is not a complete lifetime audit. Leaderboard PnL divided by leaderboard volume is not account return on capital. The sample therefore supports signal design, not a profitability claim.
+
+## Observed sample
+
+| Public profile | Closed sample | Positive rows | Sample realized PnL | Profit factor | Median entry | Recent market count / fill span | Dominant behavior |
+|---|---:|---:|---:|---:|---:|---:|---|
+| SPCEXBUYER | 200 | 93.0% | +$9.38m | 29.30 | 0.543 | 11 / 21.1h | diversified esports/sports directional |
+| vito3corleone | 7 | 100.0% | +$2.76m | n.m. | 0.500 | 10 / 148.4h | highly concentrated football |
+| kilian7kilian | 13 | 92.3% | +$1.31m | 13.65 | 0.607 | 20 / 76.6h | sports/esports favorites and mid-price entries |
+| ripley86alien | 3 | 100.0% | +$1.93m | n.m. | 0.531 | 5 / 100.2h | concentrated football |
+| nigiri99 | 200 | 53.5% | +$0.21m | 96.78 | 0.532 | 103 / 1.6h | extremely high-frequency, broad sports book |
+| mentionmarket | 198 | 69.2% | -$1.38m | 0.78 | 0.536 | 27 / 945.2h | mixed book; recent closed sample contradicts headline rank |
+| jjj1995 | 7 | 100.0% | +$1.31m | n.m. | 0.680 | 11 / 46.8h | concentrated sports |
+| e46m3 | 200 | 44.5% | approximately flat | 1.15 | 0.780 | 317 / 9.9h | very high turnover and many near-certain outcomes |
+| sainttroplay | 5 | 100.0% | +$4.19m | n.m. | 0.541 | 6 / 47.4h | single-event football concentration |
+| RN1 | 200 | 34.5% | approximately flat | 1.07 | 0.518 | 69 / 0.9h | latency/turnover-dependent |
+| swisstony | 200 | 43.0% | approximately flat | 1.33 | 0.441 | 175 / 6.1h | broad high-turnover sports book |
+
+`n.m.` means the sampled rows contained no loss, so a finite profit factor is not meaningful. This is a warning about concentration and survivorship, not proof of zero risk.
+
+## Behavioral inference
+
+1. There is no single shared strategy. The leaderboard mixes directional specialists, concentrated event bets, and turnover/latency-dependent market-making behavior.
+2. The strongest reproducible cluster is sports/esports specialization, repeated scale-in buys, and holding through resolution. Most inspected recent-fill samples were 88–100% buys.
+3. Successful directional samples concentrated around entry prices from roughly 0.30 to 0.70. Extreme-price trades appeared more often in turnover-heavy books and are harder to copy after fees.
+4. Several apparent leaders depended on one to seven settled outcomes. A single-address copy rule would import severe survivorship and concentration risk.
+5. A delayed follower does not receive the leader's entry price. Paying even a few cents more can consume the entire observable edge in a binary contract.
+6. Maker and taker economics are structurally different. Polymarket states that makers do not pay taker fees and can receive rebates, while takers pay a price-dependent fee in enabled markets. A 15-minute paper follower cannot claim a high-frequency maker's edge. See [fees](https://docs.polymarket.com/trading/fees) and [maker rebates](https://docs.polymarket.com/programs/maker-rebates).
+
+## Implemented v3 translation
+
+The research is translated into conservative, testable rules rather than wallet mirroring:
+
+- require a trader to appear in at least two of week/month/all-time top-50 lists;
+- reject low PnL/volume profiles whose result is likely turnover/rebate dependent and cap every remaining trader's vote;
+- reject profiles whose recent closed-position sample has fewer than five outcomes, non-positive PnL, or profit factor below 1.10; discount concentrated samples instead of treating them as proven;
+- discount extremely high-frequency and highly concentrated behavior;
+- require at least two independent current holdings on the same token, at least 67% weighted consensus, and at least $25,000 aggregate leader exposure;
+- require a recent net-buy confirmation from at least one supporter;
+- refuse an entry more than $0.03 above the leaders' weighted average price;
+- refuse extreme contract prices, thin liquidity, stale/near-closing markets, spreads above $0.02, and internally inconsistent binary quotes;
+- limit each paper position to 2% of equity, the whole book to 8%, one new position per tick, and one position per event;
+- block new entries after a $20 UTC-day realized loss;
+- exit on hard loss, profit target, prolonged loss of leader consensus, or maximum hold;
+- preserve `paper_only: true` and `real_orders_enabled: false` as hard invariants.
+
+No out-of-sample edge is claimed. Promotion requires forward paper results after all spread and fee assumptions; historical leaderboard selection alone is insufficient.

--- a/polyshark-ai/runtime/leader_consensus.py
+++ b/polyshark-ai/runtime/leader_consensus.py
@@ -1,0 +1,575 @@
+"""Public-data research engine for PolyShark's elite-consensus paper strategy."""
+from __future__ import annotations
+
+import json
+import math
+import os
+import statistics
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable
+
+GAMMA_MARKETS = "https://gamma-api.polymarket.com/markets"
+CLOB_BASE = "https://clob.polymarket.com"
+DATA_API_BASE = "https://data-api.polymarket.com"
+USER_AGENT = "PolyShark-Paper/3.0 (+https://github.com/Jokersochi/Jokersochi)"
+
+MIN_LIQUIDITY = float(os.getenv("PAPER_MIN_LIQUIDITY", "50000"))
+MIN_VOLUME_24H = float(os.getenv("PAPER_MIN_VOLUME_24H", "25000"))
+MIN_PRICE = float(os.getenv("PAPER_MIN_PRICE", "0.20"))
+MAX_PRICE = float(os.getenv("PAPER_MAX_PRICE", "0.80"))
+MAX_SPREAD = float(os.getenv("PAPER_MAX_SPREAD", "0.020"))
+MIN_TIME_TO_CLOSE_HOURS = float(os.getenv("PAPER_MIN_TIME_TO_CLOSE_HOURS", "0.5"))
+MAX_TIME_TO_CLOSE_DAYS = float(os.getenv("PAPER_MAX_TIME_TO_CLOSE_DAYS", "45"))
+MARKET_SCAN_LIMIT = int(os.getenv("PAPER_MARKET_SCAN_LIMIT", "200"))
+
+LEADERBOARD_PERIODS = ("WEEK", "MONTH", "ALL")
+LEADERBOARD_LIMIT = int(os.getenv("PAPER_LEADERBOARD_LIMIT", "50"))
+LEADER_POOL_LIMIT = int(os.getenv("PAPER_LEADER_POOL_LIMIT", "12"))
+MIN_LEADER_PERIODS = int(os.getenv("PAPER_MIN_LEADER_PERIODS", "2"))
+MIN_LEADER_VOLUME = float(os.getenv("PAPER_MIN_LEADER_VOLUME", "100000"))
+MIN_LEADER_EFFICIENCY = float(os.getenv("PAPER_MIN_LEADER_EFFICIENCY", "0.02"))
+MAX_LEADER_EFFICIENCY = float(os.getenv("PAPER_MAX_LEADER_EFFICIENCY", "0.75"))
+LEADER_POSITION_LIMIT = int(os.getenv("PAPER_LEADER_POSITION_LIMIT", "500"))
+LEADER_TRADE_LIMIT = int(os.getenv("PAPER_LEADER_TRADE_LIMIT", "500"))
+LEADER_CLOSED_LIMIT = int(os.getenv("PAPER_LEADER_CLOSED_LIMIT", "50"))
+LEADER_MIN_HOLDING_USD = float(os.getenv("PAPER_LEADER_MIN_HOLDING_USD", "2500"))
+LEADER_MIN_RECENT_FLOW_USD = float(os.getenv("PAPER_LEADER_MIN_RECENT_FLOW_USD", "1000"))
+LEADER_FLOW_HOURS = float(os.getenv("PAPER_LEADER_FLOW_HOURS", "12"))
+LEADER_RECENCY_HOURS = float(os.getenv("PAPER_LEADER_RECENCY_HOURS", "6"))
+LEADER_MIN_RECENT_MARKETS = int(os.getenv("PAPER_LEADER_MIN_RECENT_MARKETS", "3"))
+
+MIN_SIGNAL_SUPPORTERS = int(os.getenv("PAPER_MIN_SIGNAL_SUPPORTERS", "2"))
+MIN_SIGNAL_CONSENSUS = float(os.getenv("PAPER_MIN_SIGNAL_CONSENSUS", "0.67"))
+MIN_SIGNAL_EXPOSURE_USD = float(os.getenv("PAPER_MIN_SIGNAL_EXPOSURE_USD", "25000"))
+MAX_ENTRY_CHASE = float(os.getenv("PAPER_MAX_ENTRY_CHASE", "0.03"))
+MAX_ENTRY_DISCOUNT_WITHOUT_CONFIRMATION = float(
+    os.getenv("PAPER_MAX_ENTRY_DISCOUNT_WITHOUT_CONFIRMATION", "0.12")
+)
+REQUEST_TIMEOUT = float(os.getenv("PAPER_REQUEST_TIMEOUT", "20"))
+REQUEST_RETRIES = int(os.getenv("PAPER_REQUEST_RETRIES", "2"))
+
+FEE_RATE_BY_CATEGORY = {
+    "crypto": 0.07,
+    "sports": 0.05,
+    "finance": 0.04,
+    "politics": 0.04,
+    "economics": 0.05,
+    "culture": 0.05,
+    "weather": 0.05,
+    "mentions": 0.04,
+    "tech": 0.04,
+    "geopolitics": 0.0,
+}
+DEFAULT_FEE_RATE = 0.05
+PERIOD_WEIGHT = {"WEEK": 1.0, "MONTH": 1.15, "ALL": 0.75}
+
+
+def request_json(url: str, *, method: str = "GET", body: Any | None = None) -> Any:
+    data = None
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    for attempt in range(REQUEST_RETRIES + 1):
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in (429, 500, 502, 503, 504) or attempt >= REQUEST_RETRIES:
+                raise
+        except (urllib.error.URLError, TimeoutError):
+            if attempt >= REQUEST_RETRIES:
+                raise
+        time.sleep(0.35 * (attempt + 1))
+    raise RuntimeError("unreachable request retry state")
+
+
+def as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return default if value is None or value == "" else float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def as_json_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, list) else []
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def parse_ts(value: str) -> float:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def market_fee_rate(category: str | None, *, fees_enabled: bool = True) -> float:
+    if not fees_enabled:
+        return 0.0
+    key = (category or "").strip().lower()
+    if "geopolit" in key or key == "world":
+        return 0.0
+    return next((rate for prefix, rate in FEE_RATE_BY_CATEGORY.items() if prefix in key), DEFAULT_FEE_RATE)
+
+
+def taker_fee(shares: float, price: float, fee_rate: float) -> float:
+    if shares <= 0 or not 0 < price < 1 or fee_rate <= 0:
+        return 0.0
+    return round(shares * fee_rate * price * (1.0 - price), 5)
+
+
+@dataclass(frozen=True)
+class Leader:
+    wallet: str
+    username: str
+    score: float
+    weight: float
+    periods: tuple[str, ...]
+    ranks: tuple[str, ...]
+    median_efficiency: float
+
+
+@dataclass(frozen=True)
+class MarketInfo:
+    market_id: str
+    condition_id: str
+    question: str
+    slug: str
+    category: str
+    event_key: str
+    tokens: tuple[str, str]
+    outcomes: tuple[str, str]
+    liquidity: float
+    volume_24h: float
+    close_at: str
+    fees_enabled: bool
+
+
+@dataclass(frozen=True)
+class EliteSignal:
+    market: MarketInfo
+    token_id: str
+    outcome: str
+    supporters: tuple[str, ...]
+    supporter_wallets: tuple[str, ...]
+    supporter_count: int
+    opposition_count: int
+    consensus: float
+    leader_exposure: float
+    leader_avg_entry: float
+    recent_buyers: int
+    latest_trade_ts: int
+
+
+@dataclass(frozen=True)
+class Candidate:
+    signal: EliteSignal
+    token_mid: float
+    token_spread: float
+    opposite_mid: float
+    entry_price: float
+    fee_rate: float
+    score: float
+
+    @property
+    def market_id(self) -> str:
+        return self.signal.market.condition_id
+
+    @property
+    def event_key(self) -> str:
+        return self.signal.market.event_key
+
+    @property
+    def token_id(self) -> str:
+        return self.signal.token_id
+
+    @property
+    def outcome(self) -> str:
+        return self.signal.outcome
+
+
+def infer_category(market: dict[str, Any]) -> str:
+    events = market.get("events") if isinstance(market.get("events"), list) else []
+    event = events[0] if events and isinstance(events[0], dict) else {}
+    haystack = " ".join(
+        str(x or "")
+        for x in (
+            market.get("category"), market.get("question"), market.get("slug"), market.get("sportsMarketType"),
+            event.get("title"), event.get("slug"), event.get("seriesSlug"),
+        )
+    ).lower()
+    sports = (
+        " vs ", " win on ", "spread", "o/u", "game total", "match", "premier league", "counter-strike",
+        "dota", "esports", "tennis", "baseball", "basketball", "football", "soccer", "ufc",
+        "formula 1", "champions league", "world cup",
+    )
+    if market.get("gameStartTime") or market.get("sportsMarketType") or any(term in haystack for term in sports):
+        return "sports"
+    groups = (
+        ("crypto", ("bitcoin", "ethereum", "crypto", "solana", "xrp", "dogecoin")),
+        ("politics", ("election", "president", "senate", "congress", "governor", "nominee")),
+        ("economics", ("fed ", "interest rate", "inflation", "gdp", "unemployment", "economy")),
+        ("mentions", ("mention", "will say", "tweet", "post on")),
+        ("weather", ("weather", "temperature", "rainfall", "hurricane")),
+        ("tech", ("ai model", "technology", "iphone", "spacex", "openai")),
+        ("geopolitics", ("war", "ceasefire", "blockade", "invasion", "geopolit")),
+    )
+    return next((name for name, terms in groups if any(term in haystack for term in terms)), "other")
+
+
+def fetch_markets() -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(
+        {"limit": MARKET_SCAN_LIMIT, "closed": "false", "order": "volume24hr", "ascending": "false"}
+    )
+    data = request_json(f"{GAMMA_MARKETS}?{query}")
+    return data if isinstance(data, list) else []
+
+
+def eligible_markets(markets: Iterable[dict[str, Any]], *, now_epoch: float | None = None) -> dict[str, MarketInfo]:
+    now_epoch = time.time() if now_epoch is None else now_epoch
+    result: dict[str, MarketInfo] = {}
+    for market in markets:
+        if not bool(market.get("active", True)) or bool(market.get("closed", False)):
+            continue
+        if market.get("enableOrderBook") is False:
+            continue
+        outcomes = tuple(str(x) for x in as_json_list(market.get("outcomes")))
+        tokens = tuple(str(x) for x in as_json_list(market.get("clobTokenIds")))
+        if len(outcomes) != 2 or len(tokens) != 2 or not all(tokens):
+            continue
+        liquidity = max(as_float(market.get("liquidityNum")), as_float(market.get("liquidity")))
+        volume_24h = as_float(market.get("volume24hr"))
+        if liquidity < MIN_LIQUIDITY or volume_24h < MIN_VOLUME_24H:
+            continue
+        close_at = market.get("gameStartTime") or market.get("endDate") or market.get("endDateIso")
+        try:
+            seconds_left = parse_ts(str(close_at)) - now_epoch
+        except (TypeError, ValueError):
+            continue
+        if not MIN_TIME_TO_CLOSE_HOURS * 3600 <= seconds_left <= MAX_TIME_TO_CLOSE_DAYS * 86400:
+            continue
+        condition_id = str(market.get("conditionId") or "")
+        if not condition_id:
+            continue
+        events = market.get("events") if isinstance(market.get("events"), list) else []
+        event = events[0] if events and isinstance(events[0], dict) else {}
+        event_key = str(event.get("id") or event.get("slug") or market.get("eventId") or condition_id)
+        result[condition_id] = MarketInfo(
+            market_id=str(market.get("id") or condition_id), condition_id=condition_id,
+            question=str(market.get("question") or "Unknown market"), slug=str(market.get("slug") or ""),
+            category=infer_category(market), event_key=event_key, tokens=(tokens[0], tokens[1]),
+            outcomes=(outcomes[0], outcomes[1]), liquidity=liquidity, volume_24h=volume_24h,
+            close_at=str(close_at), fees_enabled=market.get("feesEnabled") is not False,
+        )
+    return result
+
+
+def fetch_leaderboard(period: str) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(
+        {"category": "OVERALL", "timePeriod": period, "orderBy": "PNL", "limit": LEADERBOARD_LIMIT, "offset": 0}
+    )
+    data = request_json(f"{DATA_API_BASE}/v1/leaderboard?{query}")
+    return data if isinstance(data, list) else []
+
+
+def fetch_leaderboards() -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        jobs = {executor.submit(fetch_leaderboard, period): period for period in LEADERBOARD_PERIODS}
+        for future in as_completed(jobs):
+            result[jobs[future]] = future.result()
+    return result
+
+
+def select_persistent_leaders(snapshots: dict[str, list[dict[str, Any]]]) -> list[Leader]:
+    by_wallet: dict[str, dict[str, Any]] = {}
+    for period in LEADERBOARD_PERIODS:
+        for row in snapshots.get(period, []):
+            wallet = str(row.get("proxyWallet") or "").lower()
+            volume, pnl = as_float(row.get("vol")), as_float(row.get("pnl"))
+            if len(wallet) != 42 or volume < MIN_LEADER_VOLUME or pnl <= 0:
+                continue
+            bucket = by_wallet.setdefault(wallet, {"username": str(row.get("userName") or wallet[:10]), "periods": {}})
+            bucket["periods"][period] = {
+                "rank": max(1, as_int(row.get("rank"), LEADERBOARD_LIMIT + 1)), "efficiency": pnl / volume,
+            }
+    leaders: list[Leader] = []
+    for wallet, info in by_wallet.items():
+        periods = info["periods"]
+        if len(periods) < MIN_LEADER_PERIODS:
+            continue
+        efficiency = statistics.median(float(x["efficiency"]) for x in periods.values())
+        if not MIN_LEADER_EFFICIENCY <= efficiency <= MAX_LEADER_EFFICIENCY:
+            continue
+        rank_score = sum(PERIOD_WEIGHT[p] / math.sqrt(float(row["rank"])) for p, row in periods.items())
+        score = rank_score + min(1.25, efficiency * 3.0) + 0.15 * (len(periods) - MIN_LEADER_PERIODS)
+        ordered = tuple(p for p in LEADERBOARD_PERIODS if p in periods)
+        leaders.append(
+            Leader(
+                wallet=wallet, username=str(info["username"]), score=score,
+                weight=max(0.75, min(1.50, 0.65 + score / 2.5)), periods=ordered,
+                ranks=tuple(f"{p}:{periods[p]['rank']}" for p in ordered), median_efficiency=efficiency,
+            )
+        )
+    return sorted(leaders, key=lambda leader: (len(leader.periods), leader.score), reverse=True)[:LEADER_POOL_LIMIT]
+
+
+def _fetch_one_leader(leader: Leader) -> tuple[str, dict[str, list[dict[str, Any]]]]:
+    positions_query = urllib.parse.urlencode(
+        {"user": leader.wallet, "limit": LEADER_POSITION_LIMIT, "offset": 0, "sortBy": "CURRENT", "sortDirection": "DESC"}
+    )
+    trades_query = urllib.parse.urlencode(
+        {"user": leader.wallet, "limit": LEADER_TRADE_LIMIT, "offset": 0, "takerOnly": "false"}
+    )
+    closed_query = urllib.parse.urlencode(
+        {
+            "user": leader.wallet, "limit": LEADER_CLOSED_LIMIT, "offset": 0,
+            "sortBy": "TIMESTAMP", "sortDirection": "DESC",
+        }
+    )
+    positions = request_json(f"{DATA_API_BASE}/positions?{positions_query}")
+    trades = request_json(f"{DATA_API_BASE}/trades?{trades_query}")
+    closed = request_json(f"{DATA_API_BASE}/closed-positions?{closed_query}")
+    return leader.wallet, {
+        "positions": positions if isinstance(positions, list) else [],
+        "trades": trades if isinstance(trades, list) else [],
+        "closed": closed if isinstance(closed, list) else [],
+    }
+
+
+def fetch_leader_evidence(leaders: list[Leader]) -> tuple[dict[str, dict[str, list[dict[str, Any]]]], list[str]]:
+    evidence: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    errors: list[str] = []
+    with ThreadPoolExecutor(max_workers=min(8, max(1, len(leaders)))) as executor:
+        jobs = {executor.submit(_fetch_one_leader, leader): leader for leader in leaders}
+        for future in as_completed(jobs):
+            leader = jobs[future]
+            try:
+                wallet, data = future.result()
+                evidence[wallet] = data
+            except Exception as exc:
+                errors.append(f"{leader.username}: {type(exc).__name__}")
+    return evidence, errors
+
+
+def leader_style(trades: list[dict[str, Any]]) -> tuple[str, float, int, float]:
+    markets = {str(row.get("conditionId")) for row in trades if row.get("conditionId")}
+    timestamps = [as_int(row.get("timestamp")) for row in trades if as_int(row.get("timestamp")) > 0]
+    span = (max(timestamps) - min(timestamps)) / 3600.0 if len(timestamps) > 1 else 0.0
+    if len(markets) < LEADER_MIN_RECENT_MARKETS:
+        return "insufficient-history", 0.0, len(markets), span
+    if len(trades) >= 400 and span < 3 and len(markets) >= 50:
+        return "high-frequency", 0.65, len(markets), span
+    if len(markets) < 8:
+        return "concentrated", 0.80, len(markets), span
+    return "directional", 1.0, len(markets), span
+
+
+def closed_history_quality(closed: list[dict[str, Any]]) -> tuple[str, float, dict[str, float]]:
+    pnls = [as_float(row.get("realizedPnl")) for row in closed]
+    positive = sum(value for value in pnls if value > 0)
+    negative = -sum(value for value in pnls if value < 0)
+    profit_factor = positive / negative if negative > 0 else (float("inf") if positive > 0 else 0.0)
+    total = sum(pnls)
+    positive_rate = sum(value > 0 for value in pnls) / len(pnls) if pnls else 0.0
+    top_three = sum(sorted((value for value in pnls if value > 0), reverse=True)[:3])
+    concentration = top_three / positive if positive > 0 else 1.0
+    metrics = {
+        "count": float(len(pnls)), "pnl": total, "profit_factor": profit_factor,
+        "positive_rate": positive_rate, "top3_positive_share": concentration,
+    }
+    if len(pnls) < 5:
+        return "insufficient-closed-history", 0.0, metrics
+    if total <= 0 or profit_factor < 1.10:
+        return "failed-recent-closed-history", 0.0, metrics
+    if len(pnls) < 10 or concentration > 0.85:
+        return "concentrated-closed-history", 0.75, metrics
+    return "validated-closed-history", 1.0, metrics
+
+
+def aggregate_leader_signals(
+    leaders: list[Leader], evidence: dict[str, dict[str, list[dict[str, Any]]]],
+    markets: dict[str, MarketInfo], *, now_epoch: int | None = None,
+) -> tuple[dict[str, EliteSignal], list[dict[str, Any]]]:
+    now_epoch = int(time.time()) if now_epoch is None else now_epoch
+    flow_cutoff = now_epoch - int(LEADER_FLOW_HOURS * 3600)
+    recent_cutoff = now_epoch - int(LEADER_RECENCY_HOURS * 3600)
+    votes: dict[str, list[dict[str, Any]]] = {}
+    metadata: list[dict[str, Any]] = []
+    for leader in leaders:
+        data = evidence.get(leader.wallet)
+        if not data:
+            continue
+        positions, trades, closed = data.get("positions", []), data.get("trades", []), data.get("closed", [])
+        style, multiplier, unique_markets, span = leader_style(trades)
+        history_status, history_multiplier, history_metrics = closed_history_quality(closed)
+        usable = multiplier > 0 and history_multiplier > 0
+        effective_weight = leader.weight * multiplier * history_multiplier
+        metadata.append(
+            {
+                "username": leader.username, "wallet": f"{leader.wallet[:8]}…{leader.wallet[-4:]}",
+                "periods": list(leader.periods), "ranks": list(leader.ranks),
+                "median_pnl_to_volume": round(leader.median_efficiency, 4), "style": style,
+                "recent_markets": unique_markets, "sample_span_hours": round(span, 2),
+                "closed_sample": int(history_metrics["count"]),
+                "closed_sample_pnl": round(history_metrics["pnl"], 2),
+                "closed_profit_factor": (
+                    None if math.isinf(history_metrics["profit_factor"])
+                    else round(history_metrics["profit_factor"], 4)
+                ),
+                "closed_positive_rate": round(history_metrics["positive_rate"], 4),
+                "closed_top3_positive_share": round(history_metrics["top3_positive_share"], 4),
+                "history_validation": history_status, "usable": usable,
+                "weight": round(effective_weight, 4),
+            }
+        )
+        if not usable:
+            continue
+        flows: dict[tuple[str, str], dict[str, float]] = {}
+        total_flow = 0.0
+        for trade in trades:
+            timestamp = as_int(trade.get("timestamp"))
+            condition, token = str(trade.get("conditionId") or ""), str(trade.get("asset") or "")
+            market = markets.get(condition)
+            if timestamp < flow_cutoff or market is None or token not in market.tokens:
+                continue
+            cash = as_float(trade.get("size")) * as_float(trade.get("price"))
+            if cash <= 0:
+                continue
+            signed = cash if str(trade.get("side") or "").upper() == "BUY" else -cash
+            row = flows.setdefault((condition, token), {"net": 0.0, "latest_buy": 0.0})
+            row["net"] += signed
+            if signed > 0:
+                row["latest_buy"] = max(row["latest_buy"], float(timestamp))
+            total_flow += cash
+        flow_threshold = max(LEADER_MIN_RECENT_FLOW_USD, total_flow * 0.005)
+
+        holdings: dict[str, dict[str, dict[str, float]]] = {}
+        for position in positions:
+            condition, token = str(position.get("conditionId") or ""), str(position.get("asset") or "")
+            market = markets.get(condition)
+            if market is None or token not in market.tokens or bool(position.get("redeemable", False)):
+                continue
+            if not 0 < as_float(position.get("curPrice"), -1) < 1:
+                continue
+            exposure = max(as_float(position.get("initialValue")), as_float(position.get("currentValue")))
+            entry = as_float(position.get("avgPrice"), -1)
+            if exposure < LEADER_MIN_HOLDING_USD or not 0 < entry < 1:
+                continue
+            side = holdings.setdefault(condition, {}).setdefault(token, {"exposure": 0.0, "entry_value": 0.0})
+            side["exposure"] += exposure
+            side["entry_value"] += exposure * entry
+        for condition, sides in holdings.items():
+            token, dominant = max(sides.items(), key=lambda item: item[1]["exposure"])
+            total = sum(side["exposure"] for side in sides.values())
+            net_exposure = dominant["exposure"] - (total - dominant["exposure"])
+            if dominant["exposure"] / total < 0.67 or net_exposure < LEADER_MIN_HOLDING_USD:
+                continue
+            flow = flows.get((condition, token), {"net": 0.0, "latest_buy": 0.0})
+            votes.setdefault(condition, []).append(
+                {
+                    "token": token, "username": leader.username, "wallet": leader.wallet,
+                    "weight": effective_weight, "exposure": net_exposure,
+                    "entry": dominant["entry_value"] / dominant["exposure"],
+                    "recent": flow["net"] >= flow_threshold and flow["latest_buy"] >= recent_cutoff,
+                    "latest": int(flow["latest_buy"]),
+                }
+            )
+
+    signals: dict[str, EliteSignal] = {}
+    for condition, rows in votes.items():
+        market = markets[condition]
+        by_token = {token: [row for row in rows if row["token"] == token] for token in market.tokens}
+        side_weights = {token: sum(float(row["weight"]) for row in side) for token, side in by_token.items()}
+        winner = max(side_weights, key=side_weights.get)
+        supporters = by_token[winner]
+        opposition = [row for token, side in by_token.items() if token != winner for row in side]
+        total_weight = sum(side_weights.values())
+        consensus = side_weights[winner] / total_weight if total_weight else 0.0
+        exposure = sum(float(row["exposure"]) for row in supporters)
+        weights = [math.sqrt(float(row["exposure"])) * float(row["weight"]) for row in supporters]
+        avg_entry = sum(float(row["entry"]) * weight for row, weight in zip(supporters, weights)) / sum(weights)
+        if len(supporters) < MIN_SIGNAL_SUPPORTERS or consensus < MIN_SIGNAL_CONSENSUS:
+            continue
+        if exposure < MIN_SIGNAL_EXPOSURE_USD:
+            continue
+        index = market.tokens.index(winner)
+        signals[winner] = EliteSignal(
+            market=market, token_id=winner, outcome=market.outcomes[index],
+            supporters=tuple(str(row["username"]) for row in supporters),
+            supporter_wallets=tuple(str(row["wallet"]) for row in supporters),
+            supporter_count=len(supporters), opposition_count=len(opposition), consensus=consensus,
+            leader_exposure=exposure, leader_avg_entry=avg_entry,
+            recent_buyers=sum(bool(row["recent"]) for row in supporters),
+            latest_trade_ts=max((int(row["latest"]) for row in supporters), default=0),
+        )
+    return signals, metadata
+
+
+def batch_midpoints(token_ids: list[str]) -> dict[str, float]:
+    if not token_ids:
+        return {}
+    data = request_json(f"{CLOB_BASE}/midpoints", method="POST", body=[{"token_id": token} for token in token_ids])
+    return {str(key): as_float(value, -1) for key, value in (data or {}).items()}
+
+
+def batch_spreads(token_ids: list[str]) -> dict[str, float]:
+    if not token_ids:
+        return {}
+    data = request_json(f"{CLOB_BASE}/spreads", method="POST", body=[{"token_id": token} for token in token_ids])
+    return {str(key): as_float(value, 1) for key, value in (data or {}).items()}
+
+
+def build_entry_candidates(
+    signals: dict[str, EliteSignal], mids: dict[str, float], spreads: dict[str, float],
+    *, now_epoch: int | None = None,
+) -> list[Candidate]:
+    now_epoch = int(time.time()) if now_epoch is None else now_epoch
+    cutoff = now_epoch - int(LEADER_RECENCY_HOURS * 3600)
+    result: list[Candidate] = []
+    for token, signal in signals.items():
+        if signal.recent_buyers < 1 or signal.latest_trade_ts < cutoff:
+            continue
+        opposite = signal.market.tokens[1 - signal.market.tokens.index(token)]
+        mid, opposite_mid, spread = mids.get(token, -1), mids.get(opposite, -1), spreads.get(token, 1)
+        if not (0 < mid < 1 and 0 < opposite_mid < 1) or abs(mid + opposite_mid - 1) > 0.06:
+            continue
+        if spread <= 0 or spread > MAX_SPREAD:
+            continue
+        entry = min(0.999, mid + spread / 2)
+        if not MIN_PRICE <= entry <= MAX_PRICE or entry > signal.leader_avg_entry + MAX_ENTRY_CHASE:
+            continue
+        if entry < signal.leader_avg_entry - MAX_ENTRY_DISCOUNT_WITHOUT_CONFIRMATION and signal.recent_buyers < 2:
+            continue
+        recency = max(0.0, (now_epoch - signal.latest_trade_ts) / 3600)
+        score = (
+            2 * signal.consensus + 0.35 * signal.supporter_count
+            + 0.08 * math.log10(max(signal.leader_exposure, 1)) + 0.25 * signal.recent_buyers
+            - 4 * spread - 0.03 * recency
+        )
+        result.append(
+            Candidate(
+                signal=signal, token_mid=mid, token_spread=spread, opposite_mid=opposite_mid,
+                entry_price=entry,
+                fee_rate=market_fee_rate(signal.market.category, fees_enabled=signal.market.fees_enabled), score=score,
+            )
+        )
+    return sorted(result, key=lambda candidate: candidate.score, reverse=True)

--- a/polyshark-ai/runtime/paper_trader.py
+++ b/polyshark-ai/runtime/paper_trader.py
@@ -1,312 +1,76 @@
 #!/usr/bin/env python3
-"""PolyShark autonomous paper trader.
+"""Autonomous, public-data-only Polymarket paper trader.
 
-Hard guarantees:
-- No authenticated trading endpoints are imported or called.
-- No private keys/API trading credentials are read.
-- Quotes/history come from Polymarket public Gamma/CLOB endpoints.
-- Session stops after net liquidation equity reaches TARGET_EQUITY or zero.
-
-The strategy is intentionally simple and auditable: liquid two-outcome markets,
-trend confirmation over real public price history, spread filter, capped sizing,
-and deterministic take-profit / stop-loss / max-hold exits.
+Version 3 replaces price momentum with persistent-elite consensus. The runtime
+cannot import authenticated order clients, read trading secrets, or submit an
+order. Existing v2 positions are liquidated conservatively during migration.
 """
 from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
+import sys
 import time
 import urllib.error
-import urllib.parse
-import urllib.request
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
-GAMMA_MARKETS = "https://gamma-api.polymarket.com/markets"
-CLOB_BASE = "https://clob.polymarket.com"
-USER_AGENT = "PolyShark-Paper/2.0 (+https://github.com/Jokersochi/Jokersochi)"
+RUNTIME_DIR = Path(__file__).resolve().parent
+if str(RUNTIME_DIR) not in sys.path:
+    sys.path.insert(0, str(RUNTIME_DIR))
+import leader_consensus as lc  # noqa: E402
+
+STRATEGY_VERSION = 3
+STRATEGY_NAME = "persistent-elite consensus v3"
 
 STARTING_EQUITY = float(os.getenv("PAPER_STARTING_EQUITY", "1000"))
 TARGET_EQUITY = float(os.getenv("PAPER_TARGET_EQUITY", "2000"))
 BANKRUPT_EQUITY = float(os.getenv("PAPER_BANKRUPT_EQUITY", "0"))
-MAX_POSITION_PCT = float(os.getenv("PAPER_MAX_POSITION_PCT", "0.05"))
-MAX_OPEN_POSITIONS = int(os.getenv("PAPER_MAX_OPEN_POSITIONS", "8"))
-MIN_LIQUIDITY = float(os.getenv("PAPER_MIN_LIQUIDITY", "25000"))
-MIN_VOLUME_24H = float(os.getenv("PAPER_MIN_VOLUME_24H", "10000"))
-MIN_PRICE = float(os.getenv("PAPER_MIN_PRICE", "0.15"))
-MAX_PRICE = float(os.getenv("PAPER_MAX_PRICE", "0.85"))
-MAX_SPREAD = float(os.getenv("PAPER_MAX_SPREAD", "0.035"))
-MIN_MOMENTUM_24H = float(os.getenv("PAPER_MIN_MOMENTUM_24H", "0.025"))
-MIN_MOMENTUM_6H = float(os.getenv("PAPER_MIN_MOMENTUM_6H", "0.010"))
-TAKE_PROFIT_RETURN = float(os.getenv("PAPER_TAKE_PROFIT_RETURN", "0.15"))
-STOP_LOSS_RETURN = float(os.getenv("PAPER_STOP_LOSS_RETURN", "-0.10"))
-MAX_HOLD_HOURS = float(os.getenv("PAPER_MAX_HOLD_HOURS", "72"))
-MAX_NEW_POSITIONS_PER_TICK = int(os.getenv("PAPER_MAX_NEW_POSITIONS_PER_TICK", "2"))
-MARKET_SCAN_LIMIT = int(os.getenv("PAPER_MARKET_SCAN_LIMIT", "60"))
-HISTORY_CANDIDATE_LIMIT = int(os.getenv("PAPER_HISTORY_CANDIDATE_LIMIT", "20"))
-REQUEST_TIMEOUT = float(os.getenv("PAPER_REQUEST_TIMEOUT", "15"))
+MAX_POSITION_PCT = float(os.getenv("PAPER_MAX_POSITION_PCT", "0.02"))
+MAX_TOTAL_EXPOSURE_PCT = float(os.getenv("PAPER_MAX_TOTAL_EXPOSURE_PCT", "0.08"))
+MAX_OPEN_POSITIONS = int(os.getenv("PAPER_MAX_OPEN_POSITIONS", "5"))
+MAX_NEW_POSITIONS_PER_TICK = int(os.getenv("PAPER_MAX_NEW_POSITIONS_PER_TICK", "1"))
+MAX_DAILY_REALIZED_LOSS = float(os.getenv("PAPER_MAX_DAILY_REALIZED_LOSS", "20"))
+TAKE_PROFIT_RETURN = float(os.getenv("PAPER_TAKE_PROFIT_RETURN", "0.18"))
+HARD_STOP_RETURN = float(os.getenv("PAPER_HARD_STOP_RETURN", "-0.12"))
+MAX_HOLD_HOURS = float(os.getenv("PAPER_MAX_HOLD_HOURS", "168"))
+SIGNAL_MISS_TICKS = int(os.getenv("PAPER_SIGNAL_MISS_TICKS", "2"))
+MIN_HOLD_CONSENSUS = float(os.getenv("PAPER_MIN_HOLD_CONSENSUS", "0.60"))
 
-FEE_RATE_BY_CATEGORY = {
-    "crypto": 0.07,
-    "sports": 0.03,
-    "finance": 0.04,
-    "politics": 0.04,
-    "economics": 0.05,
-    "culture": 0.05,
-    "weather": 0.05,
-    "mentions": 0.04,
-    "tech": 0.04,
-    "geopolitics": 0.0,
-}
-DEFAULT_FEE_RATE = 0.05
+# Compatibility exports used by the existing unit-test entry point.
+DEFAULT_FEE_RATE = lc.DEFAULT_FEE_RATE
+MAX_SPREAD = lc.MAX_SPREAD
+market_fee_rate = lc.market_fee_rate
+taker_fee = lc.taker_fee
+parse_ts = lc.parse_ts
+_as_float = lc.as_float
 
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def parse_ts(value: str) -> float:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
-
-
-def _request_json(url: str, *, method: str = "GET", body: Any | None = None) -> Any:
-    data = None
-    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
-    if body is not None:
-        data = json.dumps(body, separators=(",", ":")).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(url, data=data, method=method, headers=headers)
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
-        return json.load(resp)
-
-
-def _as_float(value: Any, default: float = 0.0) -> float:
-    try:
-        if value is None or value == "":
-            return default
-        return float(value)
-    except (TypeError, ValueError):
-        return default
-
-
-def _as_json_list(value: Any) -> list[Any]:
-    if isinstance(value, list):
-        return value
-    if isinstance(value, str):
-        try:
-            out = json.loads(value)
-            return out if isinstance(out, list) else []
-        except json.JSONDecodeError:
-            return []
-    return []
-
-
-def market_fee_rate(category: str | None) -> float:
-    key = (category or "").strip().lower()
-    if "geopolit" in key or "world" in key:
-        return 0.0
-    for prefix, rate in FEE_RATE_BY_CATEGORY.items():
-        if prefix in key:
-            return rate
-    return DEFAULT_FEE_RATE
-
-
-def taker_fee(shares: float, price: float, fee_rate: float) -> float:
-    """Polymarket V2 fee curve, USDC; rounded to platform precision."""
-    if shares <= 0 or not 0 < price < 1 or fee_rate <= 0:
-        return 0.0
-    fee = shares * fee_rate * price * (1.0 - price)
-    return round(fee, 5)
-
-
-@dataclass(frozen=True)
-class Candidate:
-    market_id: str
-    question: str
-    category: str
-    yes_token: str
-    no_token: str
-    yes_price: float
-    yes_spread: float
-    liquidity: float
-    volume_24h: float
-    momentum_24h: float
-    momentum_6h: float
-    end_date: str | None
-
-    @property
-    def outcome(self) -> str:
-        return "YES" if self.momentum_24h > 0 else "NO"
-
-    @property
-    def token_id(self) -> str:
-        return self.yes_token if self.outcome == "YES" else self.no_token
-
-    @property
-    def token_mid(self) -> float:
-        return self.yes_price if self.outcome == "YES" else 1.0 - self.yes_price
-
-    @property
-    def score(self) -> float:
-        trend = abs(self.momentum_24h) + 0.5 * abs(self.momentum_6h)
-        liquidity_bonus = min(0.05, math.log10(max(self.liquidity, 1.0)) / 100.0)
-        spread_penalty = self.yes_spread * 0.5
-        return trend + liquidity_bonus - spread_penalty
-
-
-def fetch_markets() -> list[dict[str, Any]]:
-    params = urllib.parse.urlencode(
-        {"limit": MARKET_SCAN_LIMIT, "closed": "false", "order": "volume24hr", "ascending": "false"}
-    )
-    data = _request_json(f"{GAMMA_MARKETS}?{params}")
-    return data if isinstance(data, list) else []
-
-
-def eligible_markets(markets: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = []
-    now = time.time()
-    for m in markets:
-        if not bool(m.get("active", True)) or bool(m.get("closed", False)):
-            continue
-        if m.get("enableOrderBook") is False:
-            continue
-        outcomes = [str(x).upper() for x in _as_json_list(m.get("outcomes"))]
-        tokens = [str(x) for x in _as_json_list(m.get("clobTokenIds"))]
-        if len(outcomes) != 2 or len(tokens) != 2 or set(outcomes) != {"YES", "NO"}:
-            continue
-        liq = max(_as_float(m.get("liquidityNum")), _as_float(m.get("liquidity")))
-        vol24 = _as_float(m.get("volume24hr"))
-        if liq < MIN_LIQUIDITY or vol24 < MIN_VOLUME_24H:
-            continue
-        end_date = m.get("endDateIso") or m.get("endDate")
-        if end_date:
-            try:
-                seconds_left = parse_ts(str(end_date)) - now
-                if seconds_left <= 0 or seconds_left > 120 * 86400:
-                    continue
-            except Exception:
-                pass
-        idx_yes = outcomes.index("YES")
-        idx_no = outcomes.index("NO")
-        row = dict(m)
-        row["_yes_token"] = tokens[idx_yes]
-        row["_no_token"] = tokens[idx_no]
-        row["_liquidity"] = liq
-        row["_volume24"] = vol24
-        out.append(row)
-    return out
-
-
-def batch_midpoints(token_ids: list[str]) -> dict[str, float]:
-    if not token_ids:
-        return {}
-    data = _request_json(f"{CLOB_BASE}/midpoints", method="POST", body=[{"token_id": tid} for tid in token_ids])
-    return {str(k): _as_float(v, -1.0) for k, v in (data or {}).items()}
-
-
-def batch_spreads(token_ids: list[str]) -> dict[str, float]:
-    if not token_ids:
-        return {}
-    data = _request_json(f"{CLOB_BASE}/spreads", method="POST", body=[{"token_id": tid} for tid in token_ids])
-    return {str(k): _as_float(v, 1.0) for k, v in (data or {}).items()}
-
-
-def batch_history(token_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
-    if not token_ids:
-        return {}
-    out: dict[str, list[dict[str, Any]]] = {}
-    now = int(time.time())
-    for start in range(0, len(token_ids), 20):
-        chunk = token_ids[start : start + 20]
-        body = {"markets": chunk, "start_ts": now - 26 * 3600, "end_ts": now, "interval": "1d", "fidelity": 60}
-        data = _request_json(f"{CLOB_BASE}/batch-prices-history", method="POST", body=body)
-        history = (data or {}).get("history", {}) if isinstance(data, dict) else {}
-        if isinstance(history, dict):
-            for tid, points in history.items():
-                if isinstance(points, list):
-                    out[str(tid)] = points
-    return out
-
-
-def momentum(points: list[dict[str, Any]], current: float) -> tuple[float, float] | None:
-    clean = sorted(
-        ((int(_as_float(p.get("t"))), _as_float(p.get("p"), -1.0)) for p in points), key=lambda x: x[0]
-    )
-    clean = [(t, p) for t, p in clean if t > 0 and 0 < p < 1]
-    if not clean or not 0 < current < 1:
-        return None
-    now = int(time.time())
-
-    def nearest_before(target: int) -> float | None:
-        eligible = [(t, p) for t, p in clean if t <= target]
-        if eligible:
-            return eligible[-1][1]
-        t, p = clean[0]
-        return p if t - target <= 3 * 3600 else None
-
-    p24 = nearest_before(now - 24 * 3600)
-    p6 = nearest_before(now - 6 * 3600)
-    if p24 is None or p6 is None:
-        return None
-    return current - p24, current - p6
-
-
-def build_candidates(markets: list[dict[str, Any]]) -> tuple[list[Candidate], dict[str, float], dict[str, float]]:
-    eligible = eligible_markets(markets)[:HISTORY_CANDIDATE_LIMIT]
-    yes_tokens = [str(m["_yes_token"]) for m in eligible]
-    all_tokens = [str(m["_yes_token"]) for m in eligible] + [str(m["_no_token"]) for m in eligible]
-    mids = batch_midpoints(all_tokens)
-    spreads = batch_spreads(all_tokens)
-    histories = batch_history(yes_tokens)
-    candidates: list[Candidate] = []
-    for m in eligible:
-        yes_token = str(m["_yes_token"])
-        no_token = str(m["_no_token"])
-        yes_mid = mids.get(yes_token, -1.0)
-        no_mid = mids.get(no_token, -1.0)
-        yes_spread = spreads.get(yes_token, 1.0)
-        no_spread = spreads.get(no_token, 1.0)
-        if not (0 < yes_mid < 1 and 0 < no_mid < 1):
-            continue
-        if abs((yes_mid + no_mid) - 1.0) > 0.08:
-            continue
-        mom = momentum(histories.get(yes_token, []), yes_mid)
-        if mom is None:
-            continue
-        mom24, mom6 = mom
-        if abs(mom24) < MIN_MOMENTUM_24H or abs(mom6) < MIN_MOMENTUM_6H or mom24 * mom6 <= 0:
-            continue
-        outcome = "YES" if mom24 > 0 else "NO"
-        token_mid = yes_mid if outcome == "YES" else no_mid
-        token_spread = yes_spread if outcome == "YES" else no_spread
-        if not (MIN_PRICE <= token_mid <= MAX_PRICE) or token_spread <= 0 or token_spread > MAX_SPREAD:
-            continue
-        candidates.append(Candidate(
-            market_id=str(m.get("id") or m.get("conditionId") or yes_token),
-            question=str(m.get("question") or "Unknown market"),
-            category=str(m.get("category") or "Other"),
-            yes_token=yes_token,
-            no_token=no_token,
-            yes_price=yes_mid,
-            yes_spread=yes_spread,
-            liquidity=float(m["_liquidity"]),
-            volume_24h=float(m["_volume24"]),
-            momentum_24h=mom24,
-            momentum_6h=mom6,
-            end_date=str(m.get("endDateIso") or m.get("endDate") or "") or None,
-        ))
-    candidates.sort(key=lambda c: c.score, reverse=True)
-    return candidates, mids, spreads
+def risk_policy_snapshot() -> dict[str, Any]:
+    return {
+        "max_position_pct": MAX_POSITION_PCT,
+        "max_total_exposure_pct": MAX_TOTAL_EXPOSURE_PCT,
+        "max_open_positions": MAX_OPEN_POSITIONS,
+        "max_new_positions_per_tick": MAX_NEW_POSITIONS_PER_TICK,
+        "max_daily_realized_loss": MAX_DAILY_REALIZED_LOSS,
+        "hard_stop_return": HARD_STOP_RETURN,
+        "take_profit_return": TAKE_PROFIT_RETURN,
+        "max_hold_hours": MAX_HOLD_HOURS,
+        "min_signal_supporters": lc.MIN_SIGNAL_SUPPORTERS,
+        "min_signal_consensus": lc.MIN_SIGNAL_CONSENSUS,
+    }
 
 
 def fresh_state() -> dict[str, Any]:
     now = utc_now()
     return {
-        "schema_version": 2,
+        "schema_version": STRATEGY_VERSION,
         "session_id": f"paper-{int(time.time())}",
         "status": "running",
         "started_at": now,
@@ -323,13 +87,27 @@ def fresh_state() -> dict[str, Any]:
         "ticks": 0,
         "last_tick_at": None,
         "last_error": None,
-        "quote_source": "Polymarket Gamma + public CLOB midpoint/spread/history",
+        "quote_source": "Polymarket Gamma + public CLOB midpoint/spread",
+        "leader_source": "Polymarket public Data API leaderboard/positions/trades",
         "real_orders_enabled": False,
         "paper_only": True,
-        "strategy": "liquid-market dual-horizon momentum v2",
+        "strategy": STRATEGY_NAME,
+        "strategy_version": STRATEGY_VERSION,
+        "risk_policy": risk_policy_snapshot(),
+        "research_snapshot": None,
         "open_positions": [],
         "closed_positions": [],
-        "audit": [{"ts": now, "event": "SESSION_RESET", "starting_equity": round(STARTING_EQUITY, 2), "target_equity": round(TARGET_EQUITY, 2), "bankrupt_equity": round(BANKRUPT_EQUITY, 2), "paper_only": True}],
+        "audit": [
+            {
+                "ts": now,
+                "event": "SESSION_RESET",
+                "starting_equity": round(STARTING_EQUITY, 2),
+                "target_equity": round(TARGET_EQUITY, 2),
+                "bankrupt_equity": round(BANKRUPT_EQUITY, 2),
+                "strategy": STRATEGY_NAME,
+                "paper_only": True,
+            }
+        ],
     }
 
 
@@ -346,112 +124,198 @@ def load_state(path: Path) -> dict[str, Any]:
 
 def save_state(path: Path, state: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    tmp.replace(path)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
 
 
 def position_liquidation(position: dict[str, Any], mid: float, spread: float) -> tuple[float, float, float]:
     shares = _as_float(position.get("shares"))
     fee_rate = _as_float(position.get("fee_rate"), DEFAULT_FEE_RATE)
-    exit_price = max(0.001, min(0.999, mid - max(0.0, spread) / 2.0))
-    gross = shares * exit_price
+    exit_price = max(0.001, min(0.999, mid - max(0.0, spread) / 2))
     fee = taker_fee(shares, exit_price, fee_rate)
-    return max(0.0, gross - fee), exit_price, fee
+    return max(0.0, shares * exit_price - fee), exit_price, fee
 
 
 def get_quote(token_id: str) -> tuple[float, float] | None:
-    mids = batch_midpoints([token_id])
-    spreads = batch_spreads([token_id])
-    mid = mids.get(token_id, -1.0)
-    spread = spreads.get(token_id, 1.0)
-    if not (0 < mid < 1 and 0 <= spread < 1):
-        return None
-    return mid, spread
+    mid = lc.batch_midpoints([token_id]).get(token_id, -1)
+    spread = lc.batch_spreads([token_id]).get(token_id, 1)
+    return (mid, spread) if 0 < mid < 1 and 0 <= spread < 1 else None
 
 
-def close_position(state: dict[str, Any], position: dict[str, Any], *, mid: float, spread: float, reason: str, now: str) -> None:
+def close_position(
+    state: dict[str, Any], position: dict[str, Any], *, mid: float, spread: float, reason: str, now: str,
+) -> None:
     net, exit_price, exit_fee = position_liquidation(position, mid, spread)
-    cash_outlay = _as_float(position.get("cash_outlay"))
-    pnl = net - cash_outlay
+    basis = _as_float(position.get("cash_outlay"))
+    pnl = net - basis
     state["cash"] = round(_as_float(state.get("cash")) + net, 6)
     state["fees_paid"] = round(_as_float(state.get("fees_paid")) + exit_fee, 6)
     state["realized_pnl"] = round(_as_float(state.get("realized_pnl")) + pnl, 6)
     closed = dict(position)
-    closed.update({"closed_at": now, "exit_price": round(exit_price, 6), "exit_fee": round(exit_fee, 6), "net_proceeds": round(net, 6), "pnl": round(pnl, 6), "return_pct": round((pnl / cash_outlay * 100.0) if cash_outlay > 0 else 0.0, 4), "close_reason": reason})
+    closed.update(
+        {
+            "closed_at": now, "exit_price": round(exit_price, 6), "exit_fee": round(exit_fee, 6),
+            "net_proceeds": round(net, 6), "pnl": round(pnl, 6),
+            "return_pct": round(pnl / basis * 100 if basis > 0 else 0, 4), "close_reason": reason,
+        }
+    )
     state.setdefault("closed_positions", []).append(closed)
-    state.setdefault("audit", []).append({"ts": now, "event": "PAPER_CLOSE", "market_id": position.get("market_id"), "outcome": position.get("outcome"), "exit_price": round(exit_price, 6), "pnl": round(pnl, 6), "reason": reason})
+    state.setdefault("audit", []).append(
+        {
+            "ts": now, "event": "PAPER_CLOSE", "market_id": position.get("market_id"),
+            "outcome": position.get("outcome"), "exit_price": round(exit_price, 6),
+            "pnl": round(pnl, 6), "reason": reason,
+        }
+    )
 
 
-def mark_and_exit_positions(state: dict[str, Any], mids: dict[str, float], spreads: dict[str, float], now: str) -> None:
+def mark_and_exit_positions(
+    state: dict[str, Any], mids: dict[str, float], spreads: dict[str, float], now: str,
+    signals: dict[str, lc.EliteSignal] | None = None, *, research_ready: bool = False,
+) -> None:
+    signals = signals or {}
     remaining: list[dict[str, Any]] = []
     for position in state.get("open_positions", []):
-        token_id = str(position.get("token_id"))
-        mid = mids.get(token_id)
-        spread = spreads.get(token_id)
-        if mid is None or spread is None or not (0 < mid < 1):
-            quote = get_quote(token_id)
+        token = str(position.get("token_id"))
+        mid, spread = mids.get(token), spreads.get(token)
+        if mid is None or spread is None or not 0 < mid < 1:
+            quote = get_quote(token)
             if quote is None:
                 remaining.append(position)
                 continue
             mid, spread = quote
-        cash_outlay = _as_float(position.get("cash_outlay"))
-        net, _, _ = position_liquidation(position, mid, spread)
-        ret = (net - cash_outlay) / cash_outlay if cash_outlay > 0 else 0.0
-        held_hours = (parse_ts(now) - parse_ts(str(position["opened_at"]))) / 3600.0
-        reason = "take_profit" if ret >= TAKE_PROFIT_RETURN else "stop_loss" if ret <= STOP_LOSS_RETURN else "max_hold" if held_hours >= MAX_HOLD_HOURS else None
+        basis = _as_float(position.get("cash_outlay"))
+        net = position_liquidation(position, mid, spread)[0]
+        return_fraction = (net - basis) / basis if basis > 0 else 0
+        held_hours = (parse_ts(now) - parse_ts(str(position["opened_at"]))) / 3600
+        legacy = lc.as_int(position.get("strategy_version"), 2) != STRATEGY_VERSION
+        misses = lc.as_int(position.get("signal_misses"), 0)
+        signal = signals.get(token)
+        if research_ready and not legacy:
+            if signal and signal.consensus >= MIN_HOLD_CONSENSUS:
+                misses = 0
+                position.update(
+                    {
+                        "leader_supporters": list(signal.supporters),
+                        "leader_consensus": round(signal.consensus, 6),
+                        "leader_exposure": round(signal.leader_exposure, 2),
+                    }
+                )
+            else:
+                misses += 1
+            position["signal_misses"] = misses
+        reason = None
+        if legacy:
+            reason = "strategy_migration"
+        elif return_fraction <= HARD_STOP_RETURN:
+            reason = "hard_stop"
+        elif return_fraction >= TAKE_PROFIT_RETURN:
+            reason = "take_profit"
+        elif held_hours >= MAX_HOLD_HOURS:
+            reason = "max_hold"
+        elif research_ready and misses >= SIGNAL_MISS_TICKS and held_hours >= 0.5:
+            reason = "leader_consensus_lost"
         if reason:
             close_position(state, position, mid=mid, spread=spread, reason=reason, now=now)
         else:
-            position["mark_price"] = round(mid, 6)
-            position["mark_spread"] = round(spread, 6)
-            position["mark_net_liquidation"] = round(net, 6)
+            position.update(
+                {"mark_price": round(mid, 6), "mark_spread": round(spread, 6), "mark_net_liquidation": round(net, 6)}
+            )
             remaining.append(position)
     state["open_positions"] = remaining
 
 
-def open_candidate(state: dict[str, Any], c: Candidate, mids: dict[str, float], spreads: dict[str, float], now: str) -> bool:
-    token_id = c.token_id
-    mid = mids.get(token_id, c.token_mid)
-    spread = spreads.get(token_id, c.yes_spread)
-    if not (0 < mid < 1) or not (0 <= spread <= MAX_SPREAD):
+def current_exposure(state: dict[str, Any]) -> float:
+    return sum(_as_float(position.get("cash_outlay")) for position in state.get("open_positions", []))
+
+
+def daily_realized_pnl(state: dict[str, Any], now: str) -> float:
+    return sum(
+        _as_float(position.get("pnl"))
+        for position in state.get("closed_positions", [])
+        if str(position.get("closed_at") or "")[:10] == now[:10]
+    )
+
+
+def open_candidate(
+    state: dict[str, Any], candidate: lc.Candidate, mids: dict[str, float], spreads: dict[str, float], now: str,
+) -> bool:
+    token = candidate.token_id
+    mid, spread = mids.get(token, candidate.token_mid), spreads.get(token, candidate.token_spread)
+    if not 0 < mid < 1 or not 0 <= spread <= lc.MAX_SPREAD:
         return False
-    entry_price = min(0.999, mid + spread / 2.0)
-    current_equity = _as_float(state.get("equity"), _as_float(state.get("cash")))
-    available = _as_float(state.get("cash"))
-    cash_outlay = min(max(0.0, current_equity * MAX_POSITION_PCT), available)
-    if cash_outlay < 5.0:
+    entry_price = min(0.999, mid + spread / 2)
+    if entry_price > candidate.signal.leader_avg_entry + lc.MAX_ENTRY_CHASE:
         return False
-    fee_rate = market_fee_rate(c.category)
-    gross_trade = cash_outlay / (1.0 + fee_rate * (1.0 - entry_price)) if fee_rate > 0 else cash_outlay
-    shares = gross_trade / entry_price
+    equity, available = _as_float(state.get("equity")), _as_float(state.get("cash"))
+    portfolio_room = max(0.0, equity * MAX_TOTAL_EXPOSURE_PCT - current_exposure(state))
+    signal = candidate.signal
+    confidence_pct = (
+        0.010 + 0.003 * max(0, signal.supporter_count - lc.MIN_SIGNAL_SUPPORTERS)
+        + 0.010 * max(0.0, signal.consensus - lc.MIN_SIGNAL_CONSENSUS)
+    )
+    cash_budget = min(equity * min(MAX_POSITION_PCT, max(0.010, confidence_pct)), available, portfolio_room)
+    if cash_budget < 5:
+        return False
+    fee_rate = candidate.fee_rate
+    gross = cash_budget / (1 + fee_rate * (1 - entry_price)) if fee_rate > 0 else cash_budget
+    shares = gross / entry_price
     entry_fee = taker_fee(shares, entry_price, fee_rate)
-    actual_outlay = gross_trade + entry_fee
-    if actual_outlay > available + 1e-9:
+    outlay = gross + entry_fee
+    if outlay > available + 1e-9:
         return False
-    state["cash"] = round(available - actual_outlay, 6)
+    market = signal.market
+    state["cash"] = round(available - outlay, 6)
     state["fees_paid"] = round(_as_float(state.get("fees_paid")) + entry_fee, 6)
-    position = {"position_id": f"{c.market_id}-{c.outcome}-{int(time.time())}", "market_id": c.market_id, "question": c.question, "category": c.category, "outcome": c.outcome, "token_id": token_id, "opened_at": now, "entry_mid": round(mid, 6), "entry_spread": round(spread, 6), "entry_price": round(entry_price, 6), "shares": round(shares, 8), "gross_trade": round(gross_trade, 6), "entry_fee": round(entry_fee, 6), "cash_outlay": round(actual_outlay, 6), "fee_rate": fee_rate, "momentum_24h": round(c.momentum_24h, 6), "momentum_6h": round(c.momentum_6h, 6), "liquidity": round(c.liquidity, 2), "volume_24h": round(c.volume_24h, 2), "end_date": c.end_date, "paper": True}
+    position = {
+        "position_id": f"{market.condition_id}-{signal.outcome}-{int(time.time())}",
+        "strategy": STRATEGY_NAME, "strategy_version": STRATEGY_VERSION,
+        "market_id": market.condition_id, "gamma_market_id": market.market_id, "event_key": market.event_key,
+        "question": market.question, "slug": market.slug, "category": market.category,
+        "outcome": signal.outcome, "token_id": token, "opened_at": now,
+        "entry_mid": round(mid, 6), "entry_spread": round(spread, 6), "entry_price": round(entry_price, 6),
+        "shares": round(shares, 8), "gross_trade": round(gross, 6), "entry_fee": round(entry_fee, 6),
+        "cash_outlay": round(outlay, 6), "fee_rate": fee_rate,
+        "leader_supporters": list(signal.supporters),
+        "leader_supporter_wallets": [f"{wallet[:8]}…{wallet[-4:]}" for wallet in signal.supporter_wallets],
+        "leader_supporter_count": signal.supporter_count, "leader_opposition_count": signal.opposition_count,
+        "leader_consensus": round(signal.consensus, 6), "leader_exposure": round(signal.leader_exposure, 2),
+        "leader_avg_entry": round(signal.leader_avg_entry, 6), "recent_buyers": signal.recent_buyers,
+        "latest_leader_trade_ts": signal.latest_trade_ts, "liquidity": round(market.liquidity, 2),
+        "volume_24h": round(market.volume_24h, 2), "close_at": market.close_at,
+        "signal_misses": 0, "paper": True,
+    }
     state.setdefault("open_positions", []).append(position)
-    state.setdefault("audit", []).append({"ts": now, "event": "PAPER_OPEN", "market_id": c.market_id, "question": c.question, "outcome": c.outcome, "entry_price": round(entry_price, 6), "cash_outlay": round(actual_outlay, 6), "momentum_24h": round(c.momentum_24h, 6), "momentum_6h": round(c.momentum_6h, 6)})
+    state.setdefault("audit", []).append(
+        {
+            "ts": now, "event": "PAPER_OPEN", "market_id": market.condition_id, "question": market.question,
+            "outcome": signal.outcome, "entry_price": round(entry_price, 6), "cash_outlay": round(outlay, 6),
+            "supporters": list(signal.supporters), "consensus": round(signal.consensus, 6),
+            "leader_avg_entry": round(signal.leader_avg_entry, 6),
+        }
+    )
     return True
 
 
 def recalc_equity(state: dict[str, Any], mids: dict[str, float], spreads: dict[str, float]) -> float:
-    cash = _as_float(state.get("cash"))
     liquidation = 0.0
     basis = 0.0
-    for p in state.get("open_positions", []):
-        token_id = str(p.get("token_id"))
-        mid = mids.get(token_id, _as_float(p.get("mark_price"), -1.0))
-        spread = spreads.get(token_id, _as_float(p.get("mark_spread"), 0.0))
-        net = position_liquidation(p, mid, spread)[0] if 0 < mid < 1 else 0.0
-        p["mark_price"] = round(mid, 6) if 0 < mid < 1 else None
-        p["mark_spread"] = round(spread, 6) if spread >= 0 else None
-        p["mark_net_liquidation"] = round(net, 6)
+    for position in state.get("open_positions", []):
+        token = str(position.get("token_id"))
+        mid = mids.get(token, _as_float(position.get("mark_price"), -1))
+        spread = spreads.get(token, _as_float(position.get("mark_spread"), 0))
+        net = position_liquidation(position, mid, spread)[0] if 0 < mid < 1 else 0
+        position.update(
+            {
+                "mark_price": round(mid, 6) if 0 < mid < 1 else None,
+                "mark_spread": round(spread, 6) if spread >= 0 else None,
+                "mark_net_liquidation": round(net, 6),
+            }
+        )
         liquidation += net
-        basis += _as_float(p.get("cash_outlay"))
-    equity = max(0.0, cash + liquidation)
+        basis += _as_float(position.get("cash_outlay"))
+    equity = max(0.0, _as_float(state.get("cash")) + liquidation)
     state["equity"] = round(equity, 6)
     state["unrealized_pnl"] = round(liquidation - basis, 6)
     return equity
@@ -460,67 +324,108 @@ def recalc_equity(state: dict[str, Any], mids: dict[str, float], spreads: dict[s
 def stop_session(state: dict[str, Any], reason: str, now: str, mids: dict[str, float], spreads: dict[str, float]) -> None:
     remaining = list(state.get("open_positions", []))
     state["open_positions"] = []
-    for p in remaining:
-        tid = str(p.get("token_id"))
-        mid = mids.get(tid, _as_float(p.get("mark_price"), 0.0))
-        spread = spreads.get(tid, _as_float(p.get("mark_spread"), 0.0))
+    for position in remaining:
+        token = str(position.get("token_id"))
+        mid = mids.get(token, _as_float(position.get("mark_price"), 0))
+        spread = spreads.get(token, _as_float(position.get("mark_spread"), 0))
         if not 0 < mid < 1:
-            state["open_positions"].append(p)
-            continue
-        close_position(state, p, mid=mid, spread=spread, reason=reason, now=now)
+            state["open_positions"].append(position)
+        else:
+            close_position(state, position, mid=mid, spread=spread, reason=reason, now=now)
     if state.get("open_positions"):
         return
-    final_equity = max(0.0, _as_float(state.get("cash")))
-    state["equity"] = round(final_equity, 6)
+    state["equity"] = round(max(0.0, _as_float(state.get("cash"))), 6)
     state["unrealized_pnl"] = 0.0
     state["status"] = "stopped_target" if reason == "target_reached" else "stopped_broke"
-    state["stopped_at"] = now
-    state["stop_reason"] = reason
-    state.setdefault("audit", []).append({"ts": now, "event": "SESSION_STOP", "reason": reason, "final_equity": round(final_equity, 6), "net_pnl": round(final_equity - _as_float(state.get("starting_equity")), 6)})
+    state["stopped_at"], state["stop_reason"] = now, reason
+    state.setdefault("audit", []).append(
+        {
+            "ts": now, "event": "SESSION_STOP", "reason": reason, "final_equity": state["equity"],
+            "net_pnl": round(state["equity"] - _as_float(state.get("starting_equity")), 6),
+        }
+    )
 
 
 def tick(state: dict[str, Any]) -> dict[str, Any]:
     now = utc_now()
+    now_epoch = int(parse_ts(now))
     if state.get("status") not in ("running", None):
-        state["last_tick_at"] = now
-        state["last_error"] = None
+        state["last_tick_at"], state["last_error"] = now, None
         return state
     if state.get("real_orders_enabled") is not False or state.get("paper_only") is not True:
         raise RuntimeError("Paper-only invariant failed")
-    markets = fetch_markets()
-    candidates, mids, spreads = build_candidates(markets)
-    open_tokens = [str(p.get("token_id")) for p in state.get("open_positions", [])]
-    missing = [tid for tid in open_tokens if tid and tid not in mids]
-    if missing:
-        mids.update(batch_midpoints(missing))
-        spreads.update(batch_spreads(missing))
-    mark_and_exit_positions(state, mids, spreads, now)
+
+    market_map = lc.eligible_markets(lc.fetch_markets(), now_epoch=now_epoch)
+    leaders: list[lc.Leader] = []
+    signals: dict[str, lc.EliteSignal] = {}
+    metadata: list[dict[str, Any]] = []
+    evidence_errors: list[str] = []
+    research_error = None
+    try:
+        leaders = lc.select_persistent_leaders(lc.fetch_leaderboards())
+        evidence, evidence_errors = lc.fetch_leader_evidence(leaders)
+        signals, metadata = lc.aggregate_leader_signals(leaders, evidence, market_map, now_epoch=now_epoch)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError) as exc:
+        research_error = f"{type(exc).__name__}: {exc}"
+    usable_evidence = sum(bool(row.get("usable")) for row in metadata)
+    research_ready = usable_evidence >= lc.MIN_SIGNAL_SUPPORTERS and research_error is None
+
+    tokens = {str(position.get("token_id")) for position in state.get("open_positions", []) if position.get("token_id")}
+    for signal in signals.values():
+        tokens.update(signal.market.tokens)
+    mids, spreads = lc.batch_midpoints(sorted(tokens)), lc.batch_spreads(sorted(tokens))
+    mark_and_exit_positions(state, mids, spreads, now, signals, research_ready=research_ready)
     equity = recalc_equity(state, mids, spreads)
+    candidates = lc.build_entry_candidates(signals, mids, spreads, now_epoch=now_epoch) if research_ready else []
+
+    state.update(
+        {
+            "schema_version": STRATEGY_VERSION, "strategy": STRATEGY_NAME,
+            "strategy_version": STRATEGY_VERSION, "risk_policy": risk_policy_snapshot(),
+        }
+    )
     if equity >= _as_float(state.get("target_equity"), TARGET_EQUITY):
         stop_session(state, "target_reached", now, mids, spreads)
     elif equity <= _as_float(state.get("bankrupt_equity"), BANKRUPT_EQUITY) + 1e-9:
         stop_session(state, "bankrupt", now, mids, spreads)
     else:
-        existing_markets = {str(p.get("market_id")) for p in state.get("open_positions", [])}
+        today_pnl = daily_realized_pnl(state, now)
+        daily_guard = today_pnl <= -MAX_DAILY_REALIZED_LOSS
+        existing_markets = {str(position.get("market_id")) for position in state.get("open_positions", [])}
+        existing_events = {str(position.get("event_key")) for position in state.get("open_positions", []) if position.get("event_key")}
         capacity = max(0, MAX_OPEN_POSITIONS - len(state.get("open_positions", [])))
         opened = 0
-        for c in candidates:
-            if capacity <= 0 or opened >= MAX_NEW_POSITIONS_PER_TICK:
-                break
-            if c.market_id in existing_markets:
-                continue
-            if open_candidate(state, c, mids, spreads, now):
-                existing_markets.add(c.market_id)
-                capacity -= 1
-                opened += 1
+        if not daily_guard:
+            for candidate in candidates:
+                if capacity <= 0 or opened >= MAX_NEW_POSITIONS_PER_TICK:
+                    break
+                if candidate.market_id in existing_markets or candidate.event_key in existing_events:
+                    continue
+                if open_candidate(state, candidate, mids, spreads, now):
+                    existing_markets.add(candidate.market_id)
+                    existing_events.add(candidate.event_key)
+                    capacity -= 1
+                    opened += 1
         recalc_equity(state, mids, spreads)
+        state["daily_risk"] = {
+            "date": now[:10], "realized_pnl": round(today_pnl, 6),
+            "new_entries_blocked": daily_guard, "limit": MAX_DAILY_REALIZED_LOSS,
+        }
+
+    state["research_snapshot"] = {
+        "generated_at": now, "ready": research_ready, "error": research_error,
+        "evidence_errors": evidence_errors, "leaderboard_periods": list(lc.LEADERBOARD_PERIODS),
+        "leaders_selected": len(leaders), "leaders_with_evidence": len(metadata),
+        "leaders_with_usable_evidence": usable_evidence,
+        "eligible_markets": len(market_map), "active_consensus_signals": len(signals),
+        "entry_candidates": len(candidates), "leaders": metadata,
+        "method": "multi-window persistence + current holding consensus + recent net-buy confirmation + anti-chase",
+        "survivorship_warning": "Leaderboard rank is not proof of future edge; all execution remains paper-only.",
+    }
     state["ticks"] = int(state.get("ticks", 0)) + 1
-    state["last_tick_at"] = now
-    state["last_error"] = None
-    if len(state.get("closed_positions", [])) > 500:
-        state["closed_positions"] = state["closed_positions"][-500:]
-    if len(state.get("audit", [])) > 2000:
-        state["audit"] = state["audit"][-2000:]
+    state["last_tick_at"], state["last_error"] = now, None
+    state["closed_positions"] = state.get("closed_positions", [])[-500:]
+    state["audit"] = state.get("audit", [])[-2000:]
     return state
 
 
@@ -532,9 +437,13 @@ def validate_state(state: dict[str, Any]) -> None:
     assert _as_float(state.get("bankrupt_equity")) == BANKRUPT_EQUITY
     assert _as_float(state.get("cash")) >= -1e-6
     assert _as_float(state.get("equity")) >= -1e-6
+    if lc.as_int(state.get("strategy_version")) == STRATEGY_VERSION:
+        assert state.get("strategy") == STRATEGY_NAME
+        assert len(state.get("open_positions", [])) <= MAX_OPEN_POSITIONS
+        assert all(position.get("paper") is True for position in state.get("open_positions", []))
     if state.get("status") == "stopped_target":
         assert not state.get("open_positions")
-        assert _as_float(state.get("equity")) >= TARGET_EQUITY - 2.0
+        assert _as_float(state.get("equity")) >= TARGET_EQUITY - 2
     if state.get("status") == "stopped_broke":
         assert not state.get("open_positions")
 
@@ -551,10 +460,25 @@ def main(argv: list[str] | None = None) -> int:
     except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError, RuntimeError) as exc:
         state["last_tick_at"] = utc_now()
         state["last_error"] = f"{type(exc).__name__}: {exc}"
-        state.setdefault("audit", []).append({"ts": state["last_tick_at"], "event": "TICK_ERROR", "error": state["last_error"]})
+        state.setdefault("audit", []).append(
+            {"ts": state["last_tick_at"], "event": "TICK_ERROR", "error": state["last_error"]}
+        )
     validate_state(state)
     save_state(path, state)
-    print(json.dumps({"status": state.get("status"), "equity": state.get("equity"), "cash": state.get("cash"), "open_positions": len(state.get("open_positions", [])), "closed_positions": len(state.get("closed_positions", [])), "ticks": state.get("ticks"), "last_error": state.get("last_error"), "paper_only": state.get("paper_only")}, ensure_ascii=False))
+    snapshot = state.get("research_snapshot") or {}
+    print(
+        json.dumps(
+            {
+                "status": state.get("status"), "strategy": state.get("strategy"),
+                "equity": state.get("equity"), "cash": state.get("cash"),
+                "open_positions": len(state.get("open_positions", [])),
+                "closed_positions": len(state.get("closed_positions", [])), "ticks": state.get("ticks"),
+                "research_ready": snapshot.get("ready"), "entry_candidates": snapshot.get("entry_candidates"),
+                "last_error": state.get("last_error"), "paper_only": state.get("paper_only"),
+            },
+            ensure_ascii=False,
+        )
+    )
     return 0
 
 

--- a/polyshark-ai/tests/test_paper_trader_runtime.py
+++ b/polyshark-ai/tests/test_paper_trader_runtime.py
@@ -1,6 +1,9 @@
 import importlib.util
+import json
 import sys
+import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 MODULE = Path(__file__).resolve().parents[1] / "runtime" / "paper_trader.py"
@@ -9,52 +12,290 @@ pt = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 sys.modules[spec.name] = pt
 spec.loader.exec_module(pt)
+lc = pt.lc
+
+
+def market() -> lc.MarketInfo:
+    return lc.MarketInfo(
+        market_id="g1",
+        condition_id="c1",
+        question="Team Alpha vs Team Beta",
+        slug="alpha-beta",
+        category="sports",
+        event_key="e1",
+        tokens=("t1", "t2"),
+        outcomes=("Alpha", "Beta"),
+        liquidity=100_000,
+        volume_24h=80_000,
+        close_at="2026-08-30T12:00:00Z",
+        fees_enabled=True,
+    )
+
+
+def leader(char: str, name: str, weight: float = 1.0) -> lc.Leader:
+    return lc.Leader(
+        wallet="0x" + char * 40,
+        username=name,
+        score=1.0,
+        weight=weight,
+        periods=("WEEK", "MONTH"),
+        ranks=("WEEK:1", "MONTH:2"),
+        median_efficiency=0.1,
+    )
+
+
+def evidence_for(who: lc.Leader, token: str, now_epoch: int, *, hedged: bool = False, recent: bool = True):
+    positions = [
+        {
+            "conditionId": "c1",
+            "asset": token,
+            "initialValue": 50_000,
+            "currentValue": 52_000,
+            "avgPrice": 0.50,
+            "curPrice": 0.52,
+            "redeemable": False,
+        }
+    ]
+    if hedged:
+        positions.append(
+            {
+                "conditionId": "c1",
+                "asset": "t2" if token == "t1" else "t1",
+                "initialValue": 50_000,
+                "currentValue": 52_000,
+                "avgPrice": 0.50,
+                "curPrice": 0.48,
+                "redeemable": False,
+            }
+        )
+    timestamp = now_epoch - 60 if recent else now_epoch - int((lc.LEADER_FLOW_HOURS + 1) * 3600)
+    trades = [
+        {"conditionId": "c1", "asset": token, "side": "BUY", "size": 5000, "price": 0.50, "timestamp": timestamp},
+        {"conditionId": "history-2", "asset": "x2", "side": "BUY", "size": 10, "price": 0.50, "timestamp": now_epoch - 120},
+        {"conditionId": "history-3", "asset": "x3", "side": "BUY", "size": 10, "price": 0.50, "timestamp": now_epoch - 180},
+    ]
+    closed = [
+        {"realizedPnl": 1000},
+        {"realizedPnl": 900},
+        {"realizedPnl": 800},
+        {"realizedPnl": 700},
+        {"realizedPnl": -500},
+    ]
+    return who.wallet, {"positions": positions, "trades": trades, "closed": closed}
 
 
 class PaperTraderRuntimeTests(unittest.TestCase):
     def test_fresh_state_is_paper_only_and_exact_targets(self):
-        s = pt.fresh_state()
-        self.assertIs(s["paper_only"], True)
-        self.assertIs(s["real_orders_enabled"], False)
-        self.assertEqual(s["starting_equity"], 1000.0)
-        self.assertEqual(s["target_equity"], 2000.0)
-        self.assertEqual(s["bankrupt_equity"], 0.0)
-        self.assertEqual(s["cash"], 1000.0)
+        state = pt.fresh_state()
+        self.assertIs(state["paper_only"], True)
+        self.assertIs(state["real_orders_enabled"], False)
+        self.assertEqual(state["starting_equity"], 1000.0)
+        self.assertEqual(state["target_equity"], 2000.0)
+        self.assertEqual(state["bankrupt_equity"], 0.0)
+        self.assertEqual(state["strategy"], pt.STRATEGY_NAME)
+        self.assertEqual(state["strategy_version"], 3)
 
-    def test_fee_formula_zero_for_fee_free_market(self):
-        self.assertEqual(pt.taker_fee(100, 0.5, 0.0), 0.0)
-
-    def test_fee_formula_matches_v2_shape(self):
+    def test_fee_formula_and_current_sports_rate(self):
         self.assertEqual(pt.taker_fee(100, 0.5, 0.04), 1.0)
-
-    def test_geopolitics_fee_free(self):
+        self.assertEqual(pt.taker_fee(100, 0.5, 0.0), 0.0)
+        self.assertEqual(pt.market_fee_rate("Sports"), 0.05)
+        self.assertEqual(pt.market_fee_rate("Sports", fees_enabled=False), 0.0)
         self.assertEqual(pt.market_fee_rate("Geopolitics"), 0.0)
 
-    def test_position_liquidation_is_conservative(self):
-        p = {"shares": 100, "fee_rate": 0.04}
-        net, px, fee = pt.position_liquidation(p, mid=0.5, spread=0.02)
-        self.assertEqual(px, 0.49)
-        self.assertLess(net, 49.0)
-        self.assertGreater(fee, 0)
+    def test_category_inference_prefers_sports_over_world_term(self):
+        row = {"question": "World Cup: Alpha vs Beta", "gameStartTime": "2026-08-30T12:00:00Z"}
+        self.assertEqual(lc.infer_category(row), "sports")
+        self.assertEqual(lc.infer_category({"question": "Fed interest rate decision"}), "economics")
 
-    def test_stop_loss_close_updates_cash_and_realized_pnl(self):
-        s = pt.fresh_state()
-        s["cash"] = 900.0
-        p = {
-            "market_id": "m1",
-            "outcome": "YES",
-            "token_id": "t1",
-            "opened_at": pt.utc_now(),
-            "shares": 200,
-            "cash_outlay": 100.0,
-            "fee_rate": 0.0,
+    def test_eligible_markets_supports_non_yes_no_binary_outcomes(self):
+        now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc).timestamp()
+        rows = [
+            {
+                "id": "g1",
+                "conditionId": "c1",
+                "question": "Alpha vs Beta",
+                "slug": "alpha-beta",
+                "active": True,
+                "closed": False,
+                "enableOrderBook": True,
+                "outcomes": json.dumps(["Alpha", "Beta"]),
+                "clobTokenIds": json.dumps(["t1", "t2"]),
+                "liquidityNum": 100_000,
+                "volume24hr": 50_000,
+                "gameStartTime": "2026-08-30T12:00:00Z",
+                "endDateIso": "2026-08-30",
+                "events": [{"id": "e1"}],
+            }
+        ]
+        eligible = lc.eligible_markets(rows, now_epoch=now)
+        self.assertIn("c1", eligible)
+        self.assertEqual(eligible["c1"].outcomes, ("Alpha", "Beta"))
+        self.assertEqual(eligible["c1"].close_at, "2026-08-30T12:00:00Z")
+
+    def test_persistent_selection_rejects_low_efficiency_and_one_window(self):
+        good = "0x" + "1" * 40
+        low = "0x" + "2" * 40
+        single = "0x" + "3" * 40
+        snapshots = {
+            "WEEK": [
+                {"proxyWallet": good, "userName": "good", "rank": "1", "vol": 1_000_000, "pnl": 100_000},
+                {"proxyWallet": low, "userName": "low", "rank": "2", "vol": 10_000_000, "pnl": 10_000},
+                {"proxyWallet": single, "userName": "single", "rank": "3", "vol": 1_000_000, "pnl": 100_000},
+            ],
+            "MONTH": [
+                {"proxyWallet": good, "userName": "good", "rank": "2", "vol": 2_000_000, "pnl": 180_000},
+                {"proxyWallet": low, "userName": "low", "rank": "3", "vol": 20_000_000, "pnl": 15_000},
+            ],
+            "ALL": [],
         }
-        s["open_positions"] = [p]
-        pt.mark_and_exit_positions(s, {"t1": 0.40}, {"t1": 0.0}, pt.utc_now())
-        self.assertEqual(s["open_positions"], [])
-        self.assertEqual(s["closed_positions"][-1]["close_reason"], "stop_loss")
-        self.assertEqual(s["cash"], 980.0)
-        self.assertEqual(s["realized_pnl"], -20.0)
+        selected = lc.select_persistent_leaders(snapshots)
+        self.assertEqual([row.username for row in selected], ["good"])
+
+    def test_recent_closed_history_rejects_a_current_leader_with_negative_sample(self):
+        status, multiplier, metrics = lc.closed_history_quality(
+            [{"realizedPnl": 100}, {"realizedPnl": 50}, {"realizedPnl": -300}, {"realizedPnl": 20}, {"realizedPnl": -10}]
+        )
+        self.assertEqual(status, "failed-recent-closed-history")
+        self.assertEqual(multiplier, 0.0)
+        self.assertLess(metrics["pnl"], 0)
+
+    def test_two_independent_holdings_and_recent_flow_create_signal(self):
+        now = 1_800_000_000
+        first, second = leader("1", "first"), leader("2", "second")
+        evidence = dict([evidence_for(first, "t1", now), evidence_for(second, "t1", now)])
+        signals, metadata = lc.aggregate_leader_signals([first, second], evidence, {"c1": market()}, now_epoch=now)
+        self.assertIn("t1", signals)
+        self.assertEqual(signals["t1"].supporter_count, 2)
+        self.assertEqual(signals["t1"].recent_buyers, 2)
+        self.assertEqual(len(metadata), 2)
+
+    def test_hedged_holding_is_not_a_directional_vote(self):
+        now = 1_800_000_000
+        first, second = leader("1", "first"), leader("2", "second")
+        evidence = dict(
+            [evidence_for(first, "t1", now, hedged=True), evidence_for(second, "t1", now)]
+        )
+        signals, _ = lc.aggregate_leader_signals([first, second], evidence, {"c1": market()}, now_epoch=now)
+        self.assertEqual(signals, {})
+
+    def test_opposed_leaders_do_not_form_consensus(self):
+        now = 1_800_000_000
+        first, second = leader("1", "first"), leader("2", "second")
+        evidence = dict([evidence_for(first, "t1", now), evidence_for(second, "t2", now)])
+        signals, _ = lc.aggregate_leader_signals([first, second], evidence, {"c1": market()}, now_epoch=now)
+        self.assertEqual(signals, {})
+
+    def test_entry_candidate_requires_fresh_flow_and_refuses_price_chasing(self):
+        now = 1_800_000_000
+        first, second = leader("1", "first"), leader("2", "second")
+        evidence = dict([evidence_for(first, "t1", now), evidence_for(second, "t1", now)])
+        signals, _ = lc.aggregate_leader_signals([first, second], evidence, {"c1": market()}, now_epoch=now)
+        accepted = lc.build_entry_candidates(signals, {"t1": 0.52, "t2": 0.48}, {"t1": 0.01}, now_epoch=now)
+        chased = lc.build_entry_candidates(signals, {"t1": 0.55, "t2": 0.45}, {"t1": 0.01}, now_epoch=now)
+        self.assertEqual(len(accepted), 1)
+        self.assertEqual(chased, [])
+
+    def test_stale_flow_can_support_holding_but_not_new_entry(self):
+        now = 1_800_000_000
+        first, second = leader("1", "first"), leader("2", "second")
+        evidence = dict(
+            [evidence_for(first, "t1", now, recent=False), evidence_for(second, "t1", now, recent=False)]
+        )
+        signals, _ = lc.aggregate_leader_signals([first, second], evidence, {"c1": market()}, now_epoch=now)
+        self.assertIn("t1", signals)
+        self.assertEqual(lc.build_entry_candidates(signals, {"t1": 0.50, "t2": 0.50}, {"t1": 0.01}, now_epoch=now), [])
+
+    def test_strategy_migration_closes_legacy_position(self):
+        state = pt.fresh_state()
+        state["cash"] = 900.0
+        state["open_positions"] = [
+            {
+                "market_id": "old",
+                "outcome": "YES",
+                "token_id": "old-token",
+                "opened_at": pt.utc_now(),
+                "shares": 200,
+                "cash_outlay": 100.0,
+                "fee_rate": 0.0,
+            }
+        ]
+        pt.mark_and_exit_positions(state, {"old-token": 0.40}, {"old-token": 0.0}, pt.utc_now())
+        self.assertEqual(state["open_positions"], [])
+        self.assertEqual(state["closed_positions"][-1]["close_reason"], "strategy_migration")
+        self.assertEqual(state["cash"], 980.0)
+
+    def test_v3_hard_stop_is_conservative(self):
+        state = pt.fresh_state()
+        state["cash"] = 900.0
+        state["open_positions"] = [
+            {
+                "strategy_version": 3,
+                "market_id": "m1",
+                "outcome": "Alpha",
+                "token_id": "t1",
+                "opened_at": pt.utc_now(),
+                "shares": 200,
+                "cash_outlay": 100.0,
+                "fee_rate": 0.0,
+                "paper": True,
+            }
+        ]
+        pt.mark_and_exit_positions(state, {"t1": 0.40}, {"t1": 0.0}, pt.utc_now())
+        self.assertEqual(state["closed_positions"][-1]["close_reason"], "hard_stop")
+        self.assertEqual(state["realized_pnl"], -20.0)
+
+    def test_consensus_loss_requires_two_observed_misses(self):
+        state = pt.fresh_state()
+        opened = datetime.now(timezone.utc) - timedelta(hours=2)
+        state["cash"] = 900.0
+        state["open_positions"] = [
+            {
+                "strategy_version": 3,
+                "market_id": "m1",
+                "outcome": "Alpha",
+                "token_id": "t1",
+                "opened_at": opened.isoformat(timespec="seconds"),
+                "shares": 200,
+                "cash_outlay": 100.0,
+                "fee_rate": 0.0,
+                "signal_misses": 1,
+                "paper": True,
+            }
+        ]
+        pt.mark_and_exit_positions(
+            state, {"t1": 0.50}, {"t1": 0.0}, pt.utc_now(), {}, research_ready=True
+        )
+        self.assertEqual(state["closed_positions"][-1]["close_reason"], "leader_consensus_lost")
+
+    def test_position_sizing_respects_small_account_cap(self):
+        signal = lc.EliteSignal(
+            market=market(),
+            token_id="t1",
+            outcome="Alpha",
+            supporters=("first", "second"),
+            supporter_wallets=("0x" + "1" * 40, "0x" + "2" * 40),
+            supporter_count=2,
+            opposition_count=0,
+            consensus=1.0,
+            leader_exposure=100_000,
+            leader_avg_entry=0.50,
+            recent_buyers=2,
+            latest_trade_ts=1_800_000_000,
+        )
+        candidate = lc.Candidate(signal, 0.50, 0.01, 0.50, 0.505, 0.05, 3.0)
+        state = pt.fresh_state()
+        self.assertTrue(pt.open_candidate(state, candidate, {"t1": 0.50}, {"t1": 0.01}, pt.utc_now()))
+        self.assertLessEqual(state["open_positions"][0]["cash_outlay"], 20.01)
+        self.assertTrue(state["open_positions"][0]["paper"])
+
+    def test_load_state_rejects_any_live_order_flag(self):
+        state = pt.fresh_state()
+        state["real_orders_enabled"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.json"
+            path.write_text(json.dumps(state), encoding="utf-8")
+            with self.assertRaises(RuntimeError):
+                pt.load_state(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

Replaces the losing dual-horizon momentum paper strategy with a public-data-only persistent-elite consensus model.

## Strategy changes

- ranks recurring traders across WEEK, MONTH, and ALL PnL windows;
- validates recent closed-position PnL/profit factor before a trader may vote;
- discounts concentrated and high-frequency behavior that a 15-minute follower cannot reproduce;
- requires at least two independent current holdings, >=67% weighted agreement, recent net-buy confirmation, and >=$25k aggregate leader exposure;
- rejects price chasing, extreme prices, thin markets, wide spreads, stale markets, and correlated positions from the same event;
- caps each position at 2% of equity, the whole book at 8%, and new entries at one per tick;
- adds a $20 UTC-day realized-loss entry guard;
- migrates all legacy v2 positions with an explicit `strategy_migration` close reason;
- updates the current official sports taker-fee coefficient from 3% to 5%.

## Safety

- `paper_only: true` and `real_orders_enabled: false` remain hard invariants.
- No authenticated order endpoint, key, or order client was added.
- Canonical `paper_state.json` is intentionally not modified in this PR; the existing workflow performs the first v3 tick after merge.

## Verification

- 16 unit tests pass.
- Static no-order guard passes for both runtime modules.
- Two live-quote dry ticks on copies of the canonical state completed without errors.
- Latest dry tick: 12 selected leaders, 10 passed closed-history validation, 51 eligible markets, 0 consensus signals, 0 entries, equity $969.90 after honest migration.

Research and limitations are documented in `polyshark-ai/research/top-trader-analysis-2026-08-29.md`.