### PR TITLE
PolyShark v4 foundation: evidence contracts and paper-only release gates

### DIFF
--- a/.github/workflows/polyshark-paper-trading-v2.yml
+++ b/.github/workflows/polyshark-paper-trading-v2.yml
@@ -3,13 +3,14 @@ name: PolyShark Paper Trading
 on:
   workflow_dispatch:
   schedule:
-    # Explicit off-peak quarter-hour slots; renamed workflow resets a stuck schedule registration.
+    # Existing scheduler is retained as a baseline until a continuously monitored worker is proven.
     - cron: "11,26,41,56 * * * *"
   push:
     branches: [main]
     paths:
       - "polyshark-ai/runtime/paper_trader.py"
-      - "polyshark-ai/tests/test_paper_trader_runtime.py"
+      - "polyshark-ai/runtime/research_contracts.py"
+      - "polyshark-ai/tests/**"
       - ".github/workflows/polyshark-paper-trading-v2.yml"
 
 permissions:
@@ -37,15 +38,19 @@ jobs:
           python - <<'PY'
           from pathlib import Path
           text = Path('polyshark-ai/runtime/paper_trader.py').read_text()
-          forbidden = ['create_order(', 'post_order(', 'cancel_all(', 'POLYMARKET_PRIVATE_KEY']
-          hits = [x for x in forbidden if x in text]
+          forbidden = [
+              'create_order(', 'post_order(', 'cancel_all(',
+              'POLYMARKET_PRIVATE_KEY', 'POLYMARKET_API_SECRET',
+              'real_orders_enabled=true', 'live_trading=true', 'DRY_RUN=false',
+          ]
+          hits = [x for x in forbidden if x.lower() in text.lower()]
           if hits:
               raise SystemExit(f'Unsafe trading primitives found: {hits}')
           print('Paper-only static guard: PASS')
           PY
 
-      - name: Unit tests
-        run: python polyshark-ai/tests/test_paper_trader_runtime.py -q
+      - name: Unit and contract tests
+        run: python -m unittest discover -s polyshark-ai/tests -p 'test_*.py' -q
 
       - name: Run one live-quote paper tick
         env:

--- a/polyshark-ai/README.md
+++ b/polyshark-ai/README.md
@@ -1,79 +1,105 @@
-# 🦈 PolyShark AI
+# 🦈 PolyShark AI v4
 
-> Автономный мультиагентный торговый сервис для Polymarket  
-> **Цель:** Selective Win Rate ≥ 80% через математическое право на воздержание
+> Evidence-first prediction-market research and paper-trading platform.
 
-## Архитектура
+## Mission
 
+PolyShark evaluates whether a calibrated probabilistic forecast contains a **robust, out-of-sample, after-cost, risk-adjusted edge** relative to market/crowd pricing.
+
+The product is **paper-only**. It must never send real orders or move real money.
+
+## Safety invariants
+
+```text
+PAPER_ONLY = TRUE
+REAL_ORDERS_ENABLED = FALSE
+REAL_MONEY = FALSE
 ```
-Data Stream → Feature Engine → ML Ensemble → Venn-Abers → EV/Kelly → Execute
+
+Any violation is a critical defect and must fail closed.
+
+## Decision pipeline
+
+```text
+REAL DATA
+  ↓
+VALIDATE + PROVENANCE
+  ↓
+INDEPENDENT FORECASTS
+  ↓
+CALIBRATION
+  ↓
+CROWD PRIOR COMPARISON
+  ↓
+NET EDGE + COST MODEL
+  ↓
+EXECUTION SIMULATION
+  ↓
+PORTFOLIO RISK / VETO
+  ↓
+PAPER DECISION
+  ↓
+OFFICIAL RESOLUTION
+  ↓
+RECONCILIATION
+  ↓
+OOS EVALUATION
+  ↓
+CHAMPION / CHALLENGER REVIEW
 ```
 
-## Быстрый старт
+## Current baseline
 
-### 1. Клонирование и настройка
+The existing production baseline is retained as **Champion / control** until a challenger demonstrates superiority on fresh OOS data. The current runtime strategy is `liquid-market dual-horizon momentum v2`.
+
+It is **not** treated as proven alpha merely because it has a positive backtest or win rate.
+
+## Research contracts
+
+`runtime/research_contracts.py` defines strict contracts for:
+
+- calibrated forecast outputs;
+- cost estimates;
+- trade dossiers;
+- explicit NO_TRADE reasons;
+- fail-closed paper-only validation;
+- canonical equity reconciliation.
+
+These contracts do not authorize execution.
+
+## Verification standard
+
+Claims must be labeled:
+
+- `NO EVIDENCE`
+- `PROMISING`
+- `IMPROVED BUT UNPROVEN`
+- `STATISTICALLY SUPPORTED`
+
+Unknown or unverified values must never be presented as facts.
+
+## Development
+
+Run the test suite from `polyshark-ai/`:
+
 ```bash
-cp .env.example .env
-# Заполни .env своими ключами (MetaMask, Supabase, Alchemy)
+python -m unittest discover -s tests -p 'test_*.py'
 ```
 
-### 2. База данных
-```bash
-# Открой Supabase Dashboard → SQL Editor
-# Выполни: database/schema.sql
-```
+## Release gate
 
-### 3. Запуск через Docker
-```bash
-docker-compose up -d redis    # сначала Redis
-docker-compose up app         # API + агент
-```
+No production release is acceptable with a critical failure in:
 
-### 4. Paper trading (обязательно сначала!)
-```
-DRY_RUN=true в .env
-Мониторь логи: docker-compose logs -f agent
-Жди 100+ сигналов перед включением реальных ордеров
-```
+- paper-only integrity;
+- ledger/reconciliation;
+- official settlement;
+- risk controls;
+- data integrity;
+- OOS validation;
+- security;
+- observability;
+- frontend/browser QA;
+- accessibility;
+- performance.
 
-## Ключевые метрики перехода в прод
-
-| Метрика | Порог |
-|---------|-------|
-| Win Rate | ≥ 70% на paper |
-| Abstention Rate | ≥ 60% |
-| Avg EV | > 0.05 |
-| Brier Score | < 0.22 |
-
-## Модули
-
-| Файл | Функция |
-|------|---------|
-| `modules/flb_cleaner.py` | Очистка FLB (Shin/FL-GLM/OO-EPC) |
-| `modules/calibration.py` | Venn-Abers IVAP калибровка |
-| `modules/ev_kelly.py` | EV + дробный Kelly |
-| `modules/validation.py` | Walk-Forward + Purging/Embargo |
-| `services/polymarket_client.py` | CLOB API (EIP-712) |
-| `services/ws_handler.py` | WebSocket стриминг |
-| `agents/orchestrator.py` | Главный агент |
-| `database/schema.sql` | Supabase DDL |
-
-## Структура файлов
-```
-polyshark-ai/
-├── agents/          # Оркестратор
-├── modules/         # Математическое ядро
-│   └── features/    # Feature engineering
-├── models/          # ML модели (LightGBM + CatBoost)
-├── services/        # Polymarket API + WebSocket
-├── database/        # Supabase schema + client
-├── api/             # FastAPI (дашборд)
-├── tests/           # Unit тесты
-└── notebooks/       # Backtesting (Jupyter)
-```
-
-## Важно
-
-⚠️ **НИКОГДА** не запускай с реальными деньгами без минимум 2 недель paper trading  
-⚠️ **НИКОГДА** не храни приватный ключ в git (добавь `.env` в `.gitignore`)  
-⚠️ Максимальная позиция: 5% банкролла (настраивается в `MAX_POSITION_PCT`)
+See `V4_AUDIT.md` for the evidence-backed baseline audit and current blockers.

--- a/polyshark-ai/V4_AUDIT.md
+++ b/polyshark-ai/V4_AUDIT.md
@@ -1,0 +1,85 @@
+# PolyShark AI v4 — Evidence-First Baseline Audit
+
+Date: 2026-08-31  
+Baseline: `main` @ `52a5b4040fe3889d3a377446d8ac22c7f334f786`  
+Working branch: `polyshark/v4-foundation`
+
+## Executive verdict
+
+**NO EVIDENCE** of a statistically supported, robust, after-cost trading edge.
+
+This is not a claim that the project cannot develop an edge. It means the current runtime does not yet provide the evidence required by v4 to make that claim.
+
+## Confirmed facts
+
+- The current runtime trader is `liquid-market dual-horizon momentum v2`.
+- Candidate selection is driven by 24h/6h momentum plus liquidity, volume, spread and price filters.
+- Current runtime uses deterministic take-profit, stop-loss and max-hold exits.
+- The repository contains a Supabase schema with markets, prices, model predictions, orders and performance metrics.
+- The current FastAPI surface is only `/health` and `/status`; positions/signals/performance/markets are TODO.
+- The scheduled paper workflow runs at quarter-hour offsets and persists `runtime/paper_state.json` by committing it to `main`.
+- Static paper-only guards exist, but the v4 invariant needs to become a reusable runtime contract rather than a workflow-only string scan.
+- Existing documentation still contains paths toward real execution and therefore conflicts with the new paper-only product policy.
+
+## P0 release blockers
+
+1. **Forecasting evidence gap** — no verified runtime chain from independent forecasts through calibration, net edge and risk-adjusted decision.
+2. **Execution realism gap** — current strategy uses midpoint/spread inputs but does not expose a complete size/depth/impact/latency execution dossier.
+3. **Settlement semantics gap** — trading exits and official event resolution are not separated as distinct lifecycles.
+4. **Canonical state gap** — committing mutable runtime state into the source branch couples execution state to Git history and creates race/reproducibility risks.
+5. **API/product evidence gap** — the API status is largely configuration-derived and contains TODO placeholders instead of canonical runtime state.
+6. **Statistical promotion gap** — no verified champion/challenger promotion gate with fresh OOS, multiple-testing awareness and stress evidence.
+
+## P1 blockers
+
+- Portfolio correlation/concentration is not a first-class runtime decision gate.
+- No explicit no-trade intelligence ledger for rejected opportunities and counterfactual outcomes.
+- No complete P&L attribution chain separating forecast alpha, selection, timing, execution and costs.
+- No immutable forecast lifecycle contract in the runtime.
+- No evidence-backed data freshness/provenance contract across critical inputs.
+- Frontend architecture and production UX requirements in the v4 brief are not yet represented by a verified route/component system in this baseline.
+
+## Root-cause hypothesis ranking
+
+### #1 — strategy is momentum-first, not forecast-first
+
+The current decision rule primarily asks whether recent price momentum is positive/negative. It does not first establish a calibrated probability and compare that probability with crowd pricing after realistic costs.
+
+### #2 — event forecasting and trade execution are conflated
+
+A stop-loss/take-profit can be useful for a paper trading experiment, but it cannot substitute for official resolution when evaluating whether a probabilistic forecast was correct.
+
+### #3 — cost/execution attribution is incomplete
+
+Without explicit expected fill, depth impact, latency and adverse-selection accounting, a positive gross signal can disappear after execution costs.
+
+### #4 — state and product truth are fragmented
+
+Runtime state, Supabase schema, API configuration and old documentation describe different versions of the product. v4 must expose one verified runtime truth and label everything else as stale/unverified.
+
+## Safe v4 foundation implemented on this branch
+
+- Added `runtime/research_contracts.py` with strict `ForecastOutput`, `TradeDossier`, `CostEstimate`, decision/rejection enums, paper-only fail-closed validation and canonical equity reconciliation.
+- Added `tests/test_research_contracts.py` covering probability bounds, explicit no-trade reasons, paper-only enforcement and equity reconciliation.
+
+These contracts are intentionally not wired into live execution yet. Integration requires tests against the actual runtime and data path; until then it remains **UNVERIFIED**.
+
+## Required next sequence
+
+1. PASS A: map every runtime path and test the actual state/ledger/settlement flow.
+2. PASS B: reconstruct historical forecasts/trades and quantify gross-to-net P&L attribution, calibration and execution gap.
+3. PASS C: adversarial leakage, look-ahead, settlement, state, paper-only and UI claims review.
+4. Freeze momentum v2 as the baseline Champion; do not optimize it against the same OOS period repeatedly.
+5. Build challengers as independent research candidates.
+6. Introduce official-resolution forecast lifecycle and immutable prediction records.
+7. Replace Git-as-runtime-state with a transactional canonical persistence layer after its exact production database/runtime is verified.
+8. Build API contracts from canonical state, then build the premium terminal UI on those contracts.
+9. Run release gate; deploy only with evidence and rollback verification.
+
+## Non-negotiable policy
+
+`PAPER_ONLY = TRUE`  
+`REAL_ORDERS_ENABLED = FALSE`  
+`REAL_MONEY = FALSE`
+
+Any violation is a **CRITICAL DEFECT** and must fail closed.

--- a/polyshark-ai/runtime/research_contracts.py
+++ b/polyshark-ai/runtime/research_contracts.py
@@ -1,0 +1,142 @@
+"""Strict, paper-only research contracts for PolyShark v4.
+
+These contracts deliberately do not execute trades. They define the evidence that
+must exist before a paper decision can be accepted by the research pipeline.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class Decision(str, Enum):
+    TRADE = "TRADE"
+    NO_TRADE = "NO_TRADE"
+
+
+class RejectReason(str, Enum):
+    INSUFFICIENT_EDGE = "INSUFFICIENT_EDGE"
+    HIGH_UNCERTAINTY = "HIGH_UNCERTAINTY"
+    BAD_LIQUIDITY = "BAD_LIQUIDITY"
+    HIGH_SPREAD = "HIGH_SPREAD"
+    HIGH_SLIPPAGE = "HIGH_SLIPPAGE"
+    BAD_RESOLUTION_RULE = "BAD_RESOLUTION_RULE"
+    STALE_DATA = "STALE_DATA"
+    CONFLICTING_SOURCES = "CONFLICTING_SOURCES"
+    HIGH_CORRELATION = "HIGH_CORRELATION"
+    RISK_LIMIT = "RISK_LIMIT"
+    MODEL_DISAGREEMENT = "MODEL_DISAGREEMENT"
+    EXECUTION_UNCERTAINTY = "EXECUTION_UNCERTAINTY"
+    REGIME_UNSUPPORTED = "REGIME_UNSUPPORTED"
+
+
+@dataclass(frozen=True)
+class ForecastOutput:
+    probability: float
+    calibrated_probability: float
+    confidence: float
+    uncertainty: float
+    evidence: tuple[Mapping[str, Any], ...] = ()
+    counter_evidence: tuple[Mapping[str, Any], ...] = ()
+    source_quality: float = 0.0
+    timestamp: str = ""
+    regime: str = ""
+    data_quality: float = 0.0
+
+    def validate(self) -> None:
+        for name in ("probability", "calibrated_probability", "confidence", "uncertainty", "source_quality", "data_quality"):
+            value = float(getattr(self, name))
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be within [0, 1]")
+        if not self.timestamp:
+            raise ValueError("timestamp is required")
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    fees: float = 0.0
+    spread: float = 0.0
+    slippage: float = 0.0
+    price_impact: float = 0.0
+    latency: float = 0.0
+    liquidity: float = 0.0
+    adverse_selection: float = 0.0
+
+    @property
+    def total(self) -> float:
+        return sum((self.fees, self.spread, self.slippage, self.price_impact, self.latency, self.adverse_selection))
+
+
+@dataclass(frozen=True)
+class TradeDossier:
+    market_id: str
+    question: str
+    resolution_rule: str
+    resolution_source: str
+    market_price: float
+    bid: float
+    ask: float
+    spread: float
+    liquidity: float
+    volume: float
+    time_to_resolution_seconds: float
+    crowd_probability: float
+    raw_model_probability: float
+    calibrated_probability: float
+    probability_uncertainty: float
+    agent_agreement: float
+    agent_disagreement: float
+    news_score: float
+    microstructure_score: float
+    fundamental_score: float
+    regime_score: float
+    estimated_edge: float
+    estimated_net_edge: float
+    expected_cost: CostEstimate
+    execution_probability: float
+    gross_ev: float
+    net_ev: float
+    risk_adjusted_ev: float
+    position_size: float
+    max_loss: float
+    portfolio_exposure: float
+    correlation_exposure: float
+    decision: Decision
+    confidence: float
+    rejection_reason: RejectReason | None = None
+    paper_only: bool = True
+    real_orders_enabled: bool = False
+
+    def validate(self) -> None:
+        if not self.market_id or not self.question:
+            raise ValueError("market identity is required")
+        if not self.resolution_rule or not self.resolution_source:
+            raise ValueError("official resolution metadata is required")
+        for name in ("market_price", "bid", "ask", "spread", "crowd_probability", "raw_model_probability", "calibrated_probability", "probability_uncertainty", "agent_agreement", "agent_disagreement", "execution_probability", "confidence"):
+            value = float(getattr(self, name))
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be within [0, 1]")
+        if self.bid > self.ask:
+            raise ValueError("bid cannot exceed ask")
+        if self.estimated_net_edge != self.estimated_edge - self.expected_cost.total:
+            raise ValueError("estimated_net_edge must equal edge minus modeled costs")
+        if self.decision is Decision.NO_TRADE and self.rejection_reason is None:
+            raise ValueError("NO_TRADE requires an explicit rejection_reason")
+        if self.decision is Decision.TRADE and self.rejection_reason is not None:
+            raise ValueError("TRADE cannot carry a rejection_reason")
+        if not self.paper_only or self.real_orders_enabled:
+            raise ValueError("paper-only invariant violated")
+
+
+def require_paper_only(state: Mapping[str, Any]) -> None:
+    """Fail closed if a state/config attempts to enable real execution."""
+    if state.get("real_orders_enabled") is True or state.get("live_trading") is True:
+        raise RuntimeError("PAPER_ONLY_VIOLATION")
+    if state.get("paper_only") is False:
+        raise RuntimeError("PAPER_ONLY_VIOLATION")
+
+
+def reconcile_equity(starting_equity: float, realized_pnl: float, unrealized_pnl: float, fees: float, costs: float) -> float:
+    """Canonical research equity equation."""
+    return starting_equity + realized_pnl + unrealized_pnl - fees - costs

--- a/polyshark-ai/tests/test_research_contracts.py
+++ b/polyshark-ai/tests/test_research_contracts.py
@@ -1,0 +1,50 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+MODULE = Path(__file__).resolve().parents[1] / "runtime" / "research_contracts.py"
+spec = importlib.util.spec_from_file_location("research_contracts", MODULE)
+contracts = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(contracts)
+
+
+class ResearchContractsTests(unittest.TestCase):
+    def test_forecast_rejects_invalid_probability(self):
+        forecast = contracts.ForecastOutput(
+            probability=1.1,
+            calibrated_probability=0.5,
+            confidence=0.5,
+            uncertainty=0.2,
+            timestamp="2026-08-31T00:00:00+00:00",
+        )
+        with self.assertRaises(ValueError):
+            forecast.validate()
+
+    def test_no_trade_requires_reason(self):
+        cost = contracts.CostEstimate(fees=0.01)
+        dossier = contracts.TradeDossier(
+            market_id="m1", question="Q", resolution_rule="official rule", resolution_source="official",
+            market_price=0.50, bid=0.49, ask=0.51, spread=0.02, liquidity=10000, volume=5000,
+            time_to_resolution_seconds=3600, crowd_probability=0.50, raw_model_probability=0.60,
+            calibrated_probability=0.58, probability_uncertainty=0.10, agent_agreement=0.70,
+            agent_disagreement=0.20, news_score=0.0, microstructure_score=0.1, fundamental_score=0.2,
+            regime_score=0.8, estimated_edge=0.08, estimated_net_edge=0.07, expected_cost=cost,
+            execution_probability=0.9, gross_ev=0.08, net_ev=0.07, risk_adjusted_ev=0.05,
+            position_size=10, max_loss=10, portfolio_exposure=0.01, correlation_exposure=0.0,
+            decision=contracts.Decision.NO_TRADE, confidence=0.7,
+        )
+        with self.assertRaises(ValueError):
+            dossier.validate()
+
+    def test_paper_only_fails_closed(self):
+        with self.assertRaises(RuntimeError):
+            contracts.require_paper_only({"paper_only": True, "real_orders_enabled": True})
+
+    def test_equity_reconciliation(self):
+        value = contracts.reconcile_equity(1000, -10, 5, 2, 3)
+        self.assertEqual(value, 990)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the first safe slice of the PolyShark v4 overhaul.

### Included
- Evidence-backed baseline audit in `polyshark-ai/V4_AUDIT.md`.
- Strict research contracts for forecasts, costs, trade dossiers, NO_TRADE reasons, paper-only invariants and equity reconciliation.
- Unit tests for the new contracts.
- README aligned to paper-only v4 policy; removes the old implication that real execution is a production goal.
- Paper workflow now runs the full test discovery and stronger paper-only static guard.

### Deliberately not included yet
- No live execution capability.
- No champion promotion.
- No strategy tuning against the current OOS period.
- No replacement of canonical runtime persistence until the actual production persistence path is fully verified.
- No production UI rewrite before API/runtime truth is mapped.

### Current verdict
NO EVIDENCE of statistically supported robust after-cost edge.

Next phase is PASS A/B/C audit followed by baseline reconstruction and challenger evaluation.